### PR TITLE
Add analysis info to header for yaml, fix missing template information in packed .msapp

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -357,3 +357,6 @@ MigrationBackup/
 
 # Ionide (cross platform F# VS Code tools) working folder
 .ionide/
+
+# Ignore .idea IDE files
+.idea/

--- a/src/PAModel/CanvasDocument.cs
+++ b/src/PAModel/CanvasDocument.cs
@@ -11,28 +11,29 @@ using Microsoft.PowerPlatform.Formulas.Tools.SourceTransforms;
 using Microsoft.PowerPlatform.Formulas.Tools.Utility;
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 
 namespace Microsoft.PowerPlatform.Formulas.Tools
 {
     /// <summary>
-    /// Represents a PowerApps document.  This can be save/loaded from a MsApp or Source representation. 
-    /// This is a full in-memory representation of the msapp file. 
+    /// Represents a PowerApps document.  This can be save/loaded from a MsApp or Source representation.
+    /// This is a full in-memory representation of the msapp file.
     /// </summary>
     public class CanvasDocument
     {
         /// <summary>
-        /// Current source format version. 
+        /// Current source format version.
         /// </summary>
         public static Version CurrentSourceVersion => SourceSerializer.CurrentSourceVersion;
 
         // Rules for CanvasDocument
-        // - Save/Load must faithfully roundtrip an msapp exactly. 
-        // - this is an in-memory representation - so it must parse/shard everything on load. 
-        // - Save should not mutate any state. 
+        // - Save/Load must faithfully roundtrip an msapp exactly.
+        // - this is an in-memory representation - so it must parse/shard everything on load.
+        // - Save should not mutate any state.
 
-        // Track all unknown "files". Ensures round-tripping isn't lossy.         
+        // Track all unknown "files". Ensures round-tripping isn't lossy.
         // Only contains files of FileKind.Unknown
         internal Dictionary<FilePath, FileEntry> _unknownFiles = new Dictionary<FilePath, FileEntry>();
 
@@ -43,7 +44,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         internal EditorStateStore _editorStateStore;
         internal TemplateStore _templateStore;
 
-        // Various data sources        
+        // Various data sources
         // This is references\dataSources.json
         // Also includes entries for DataSources made from a DataComponent
         // Key is parent entity name (datasource name for non cds data sources)
@@ -77,7 +78,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         internal IDictionary<string, LocalDatabaseReferenceJson> _dataSourceReferences;
 
         // Extracted from _properties.LibraryDependencies
-        // Must preserve server ordering. 
+        // Must preserve server ordering.
         internal ComponentDependencyInfo[] _libraryReferences;
 
         internal FileEntry _logoFile;
@@ -85,7 +86,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         // Save for roundtripping.
         internal Entropy _entropy = new Entropy();
 
-        // Checksum from existing msapp. 
+        // Checksum from existing msapp.
         internal ChecksumJson _checksum;
 
         // Track all asset files, key is file name
@@ -103,7 +104,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         #region Save/Load
 
         /// <summary>
-        /// Load an .msapp file for a Canvas Document. 
+        /// Load an .msapp file for a Canvas Document.
         /// </summary>
         /// <param name="fullPathToMsApp">path to an .msapp file</param>
         /// <returns>A tuple of the document and errors and warnings. If there are errors, the document is null.  </returns>
@@ -219,7 +220,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
 
         #endregion
 
-        // Wrapper to ensure consistent invariants between loading a document, exception handling, and returning errors. 
+        // Wrapper to ensure consistent invariants between loading a document, exception handling, and returning errors.
         private static CanvasDocument Wrapper(Func<CanvasDocument> worker, ErrorContainer errors)
         {
             CanvasDocument document = null;
@@ -322,7 +323,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             _localAssetInfoJson = other._localAssetInfoJson.JsonClone();
         }
 
-        // iOrder is used to preserve ordering value for round-tripping. 
+        // iOrder is used to preserve ordering value for round-tripping.
         internal void AddDataSourceForLoad(DataSourceEntry ds, int? order = null)
         {
             // Key is parent entity name
@@ -379,7 +380,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             var componentInstanceTransform = new ComponentInstanceTransform(errors);
             var componentDefTransform = new ComponentDefinitionTransform(errors, _templateStore, componentInstanceTransform);
 
-            // Transform component definitions and populate template set of component instances that need updates 
+            // Transform component definitions and populate template set of component instances that need updates
             foreach (var ctrl in _components)
             {
                 AddComponentDefaults(ctrl.Value, templateDefaults);
@@ -436,7 +437,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             var componentInstanceTransform = new ComponentInstanceTransform(errors);
             var componentDefTransform = new ComponentDefinitionTransform(errors, _templateStore, componentInstanceTransform);
 
-            // Transform component definitions and populate template set of component instances that need updates 
+            // Transform component definitions and populate template set of component instances that need updates
             foreach (var ctrl in _components)
             {
                 componentDefTransform.BeforeWrite(ctrl.Value);
@@ -469,10 +470,10 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
         }
 
 
-        // Called after loading. This will check internal fields and fill in consistency data. 
+        // Called after loading. This will check internal fields and fill in consistency data.
         internal void OnLoadComplete(ErrorContainer errors)
         {
-            // Do integrity checks. 
+            // Do integrity checks.
             if (_header == null)
             {
                 errors.FormatNotSupported("Missing header file");
@@ -505,7 +506,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             }
         }
 
-        // Get ComponentIds for components we've imported. 
+        // Get ComponentIds for components we've imported.
         internal HashSet<string> GetImportedComponents()
         {
             var set = new HashSet<string>();
@@ -684,10 +685,10 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
             }
         }
 
-        // Helper for traversing and ensuring unique control names. 
+        // Helper for traversing and ensuring unique control names.
         internal class UniqueControlNameVistor
         {
-            // Control names are case sensitive. 
+            // Control names are case sensitive.
             private readonly Dictionary<string, SourceLocation?> _names = new Dictionary<string, SourceLocation?>(StringComparer.Ordinal);
             private readonly ErrorContainer _errors;
 
@@ -698,7 +699,7 @@ namespace Microsoft.PowerPlatform.Formulas.Tools
 
             public void Visit(BlockNode node)
             {
-                // Ignore test templates here. 
+                // Ignore test templates here.
                 // Test templates have control-like syntax, but allowed to repeat names:
                 //    Step4 As TestStep:
                 if (AppTestTransform.IsTestSuite(node.Name.Kind.TypeName))

--- a/src/PAModel/Schemas/AnalysisOptionsJson.cs
+++ b/src/PAModel/Schemas/AnalysisOptionsJson.cs
@@ -1,0 +1,14 @@
+﻿// ------------------------------------------------------------------------------
+//  <copyright company="Microsoft Corporation">
+//      Copyright (c) Microsoft Corporation.  All rights reserved.
+//  </copyright>
+// ------------------------------------------------------------------------------
+
+namespace Microsoft.AppMagic.Authoring.Persistence
+{
+    internal class AnalysisOptionsJson
+    {
+        public bool DataflowAnalysisEnabled { get; set; }
+        public bool DataflowAnalysisFlagStateToggledByUser { get; set; }
+    }
+}

--- a/src/PAModel/Schemas/HeaderJson.cs
+++ b/src/PAModel/Schemas/HeaderJson.cs
@@ -3,6 +3,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
@@ -14,6 +15,8 @@ namespace Microsoft.AppMagic.Authoring.Persistence
         public Version MinVersionToLoad { get; set; }
         public Version MSAppStructureVersion { get; set; }
         public DateTime? LastSavedDateTimeUTC { get; set; }
+
+        public AnalysisOptionsJson AnalysisOptions { get; set; }
 
         [JsonExtensionData]
         public Dictionary<string, JsonElement> ExtensionData { get; set; }


### PR DESCRIPTION
Fixes this bug present due to newly introduced .msapp properties.
![image](https://github.com/microsoft/PowerApps-Language-Tooling/assets/62115878/7b80d732-d177-4e27-8d90-27abe511888f)
