### PR TITLE
Proof of Concept - YamlDotNet serialization and deserializaiton

### DIFF
--- a/src/PAModel/Microsoft.PowerPlatform.Formulas.Tools.csproj
+++ b/src/PAModel/Microsoft.PowerPlatform.Formulas.Tools.csproj
@@ -35,7 +35,7 @@
       <AssemblyVersion>$(MinVer)</AssemblyVersion>
     </PropertyGroup>
   </Target>
-    
+
   <ItemGroup>
     <EmbeddedResource Include="ControlTemplates/commonStyleProperties.xml" />
     <EmbeddedResource Include="Themes/DefaultTheme.json" />
@@ -52,7 +52,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="13.0.2" />
     <PackageReference Include="System.Text.Json" Version="6.0.9" />
     <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
-    <PackageReference Include="YamlDotNet" Version="11.2.1" />
+    <PackageReference Include="YamlDotNet" Version="13.7.1" />
   </ItemGroup>
   <ItemGroup Condition="'$(GitExists)' == true">
     <PackageReference Include="MinVer" Version="2.3.0">

--- a/src/PAModel/PAConvert/Yaml2/MultilineStyleEmitter.cs
+++ b/src/PAModel/PAConvert/Yaml2/MultilineStyleEmitter.cs
@@ -1,0 +1,40 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Linq;
+using YamlDotNet.Core;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.EventEmitters;
+
+namespace Microsoft.PowerPlatform.Formulas.Tools.Yaml2;
+
+/// <summary>
+/// Used to instruct YamlDotNet to serialize multiline strings with
+/// '|' (literal style) instead of '>' (folded style)
+/// </summary>
+public class MultilineStyleEmitter : ChainedEventEmitter
+{
+    public MultilineStyleEmitter(IEventEmitter nextEmitter)
+        : base(nextEmitter)
+    {
+    }
+
+    public override void Emit(ScalarEventInfo eventInfo, IEmitter emitter)
+    {
+
+        if (typeof(string).IsAssignableFrom(eventInfo.Source.Type))
+        {
+            var value = eventInfo.Source.Value as string;
+            if (!string.IsNullOrEmpty(value))
+            {
+                if (value.Any(Parser.CharacterUtils.IsLineTerm))
+                    eventInfo = new ScalarEventInfo(eventInfo.Source)
+                    {
+                        Style = ScalarStyle.Literal,
+                    };
+            }
+        }
+
+        nextEmitter.Emit(eventInfo, emitter);
+    }
+}

--- a/src/PAModel/PAConvert/Yaml2/YamlPocoConverter.cs
+++ b/src/PAModel/PAConvert/Yaml2/YamlPocoConverter.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using YamlDotNet.Core;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Microsoft.PowerPlatform.Formulas.Tools.Yaml2;
+
+public class YamlPocoConverter
+{
+    private readonly Lazy<ISerializer> _serializer =
+        new (() => new SerializerBuilder()
+            .WithQuotingNecessaryStrings(true)
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .WithEventEmitter(next => new MultilineStyleEmitter(next))
+            .Build());
+
+    private readonly Lazy<IDeserializer> _deserializer =
+        new (new DeserializerBuilder()
+            .WithDuplicateKeyChecking()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .Build());
+
+    public ISerializer Serializer => _serializer.Value;
+    public IDeserializer Deserializer => _deserializer.Value;
+
+    public string Canonicalize<T>(string yaml)
+    {
+        return Serializer.Serialize(Deserializer.Deserialize<T>(yaml));
+    }
+}

--- a/src/PAModelTests/PAModelTests.csproj
+++ b/src/PAModelTests/PAModelTests.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="coverlet.collector" Version="1.2.0" />
-    <PackageReference Include="YamlDotNet" Version="11.2.1" />
+    <PackageReference Include="YamlDotNet" Version="13.7.1" />
     <PackageReference Include="xunit" Version="2.5.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.5.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/PAModelTests/Yaml2SerializerTests/YamlControlDiscriminationPoC/ControlInfoPoC.cs
+++ b/src/PAModelTests/Yaml2SerializerTests/YamlControlDiscriminationPoC/ControlInfoPoC.cs
@@ -1,0 +1,138 @@
+using FluentAssertions;
+using Microsoft.PowerPlatform.Formulas.Tools.Yaml2;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace PAModelTests.Yaml2SerializerTests.YamlControlDiscriminationPoC;
+
+public class Screen
+{
+    public string Name { get; set; }
+    public IList<ControlInfoPoC> Controls { get; set; }
+}
+
+public abstract class ControlInfoPoC
+{
+    protected ControlInfoPoC(string controlType)
+    {
+        ControlType = controlType;
+    }
+
+    // Used by deserializer to determine which Type to deserialize as, when in a collection of the base type
+    [YamlMember(Order = -1)]
+    public string ControlType { get; protected set; }
+
+    public Position Position { get; set; }
+    public Size Size { get; set; }
+    public string ToolTip { get; set; }
+}
+
+public class Position
+{
+    public int X { get; set; }
+    public int Y { get; set; }
+}
+
+public class Size
+{
+    public int Height { get; set; }
+    public int Width { get; set; }
+}
+
+public class Button : ControlInfoPoC
+{
+    internal const string ControlVersion = "button@v1";
+    public Button()
+        : base(ControlVersion)
+    {
+    }
+
+    public string ButtonText { get; set; }
+    public string ClickAction { get; set; }
+}
+
+public class ButtonV2 : ControlInfoPoC
+{
+    internal const string ControlVersion = "button@v2";
+    public ButtonV2()
+        : base(ControlVersion)
+    {
+    }
+
+    // Simulated breaking change - Button v2 renamed "ButtonText" to "Label"
+    public string Label { get; set; }
+    public string ClickAction { get; set; }
+}
+
+public class TextLabel : ControlInfoPoC
+{
+    internal const string ControlVersion = "textlabel@v1";
+    public TextLabel()
+        : base(ControlVersion)
+    {
+    }
+
+    public string Label { get; set; }
+}
+
+public class TextInput : ControlInfoPoC
+{
+    internal const string ControlVersion = "textinput@v1";
+    public TextInput()
+        : base(ControlVersion)
+    {
+    }
+
+    public string Watermark { get; set; }
+}
+
+[TestClass]
+public class ControlDiscriminationTests
+{
+    [TestMethod]
+    public void ControlDiscriminationPoC()
+    {
+        var serializer = new YamlPocoConverter().Serializer;
+
+        // Note that this deserializer is NOT the version in YamlPocoConverter, as we are adding
+        // a type discriminator here that is not yet present there as a proof of concept.
+        var deserializer = new DeserializerBuilder()
+            .WithDuplicateKeyChecking()
+            .WithNamingConvention(CamelCaseNamingConvention.Instance)
+            .WithTypeDiscriminatingNodeDeserializer(options =>
+                {
+                    var typeMapping = new Dictionary<string, Type>
+                    {
+                        { Button.ControlVersion, typeof(Button) },
+                        { ButtonV2.ControlVersion, typeof(ButtonV2) },
+                        { TextInput.ControlVersion, typeof(TextInput) },
+                        { TextLabel.ControlVersion, typeof(TextLabel) }
+                    };
+                    options.AddKeyValueTypeDiscriminator<ControlInfoPoC>("controlType", typeMapping);
+                })
+            .Build();
+
+        var screen = new Screen
+        {
+            Name = "Screen 1",
+            Controls = new List<ControlInfoPoC>
+            {
+                new TextLabel { Label = "Input the thing:" },
+                new TextInput { Watermark = "example thing" },
+                new Button { ButtonText = "OK", ClickAction = "submit" },
+                new ButtonV2 { Label = "Cancel", ClickAction = "cancel" }
+            }
+        };
+
+        var yaml = serializer.Serialize(screen);
+        var deserialized = deserializer.Deserialize<Screen>(yaml);
+
+        // Confirm that the deserialization picked the right types
+        deserialized.Controls.Should().HaveCount(4);
+        deserialized.Controls[0].Should().BeOfType<TextLabel>();
+        deserialized.Controls[1].Should().BeOfType<TextInput>();
+        deserialized.Controls[2].Should().BeOfType<Button>();
+        deserialized.Controls[3].Should().BeOfType<ButtonV2>();
+    }
+}

--- a/src/PAModelTests/Yaml2SerializerTests/YamlPocoConverterTests.cs
+++ b/src/PAModelTests/Yaml2SerializerTests/YamlPocoConverterTests.cs
@@ -1,0 +1,166 @@
+using FluentAssertions;
+using Microsoft.PowerPlatform.Formulas.Tools;
+using Microsoft.PowerPlatform.Formulas.Tools.Yaml;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.IO;
+using Microsoft.PowerPlatform.Formulas.Tools.Yaml2;
+using PAModelTests.Yaml2SerializerTests.YamlPocoTypes;
+using YamlDotNet.Core;
+using YamlDotNet.Serialization;
+
+namespace PAModelTests.Yaml2SerializerTests;
+
+[TestClass]
+public class YamlPocoConverterTests
+{
+    [TestMethod]
+    public void IntegersAndDoublesShouldSerializeCorrectly()
+    {
+        var obj = new NumberObject { Integer = 3, Double = Math.PI };
+        var serializer = new YamlPocoConverter().Serializer;
+        var serialized = serializer.Serialize(obj);
+
+        var expected = $"integer: 3{Environment.NewLine}double: 3.141592653589793{Environment.NewLine}";
+        serialized.Should().BeEquivalentTo(expected);
+    }
+
+    [TestMethod]
+    public void OrderedTypeAppliesOnSerialization()
+    {
+        var obj = new OrderedObject
+        {
+            Arg3 = 5,
+            Arg2 = "foo",
+            Arg1 = true
+        };
+
+        var serializer = new YamlPocoConverter().Serializer;
+        var serialized = serializer.Serialize(obj);
+
+        var expected = @"arg1: true
+arg2: foo
+arg3: 5
+";
+        serialized.Should().BeEquivalentTo(expected);
+    }
+
+    [TestMethod]
+    public void CanonicalizeShouldSortDisorderedProperties()
+    {
+        var initial = $"arg3: 3{Environment.NewLine}arg2: foo{Environment.NewLine}arg1: false{Environment.NewLine}";
+        var actual = new YamlPocoConverter().Canonicalize<OrderedObject>(initial);
+        var expected = $"arg1: false{Environment.NewLine}arg2: foo{Environment.NewLine}arg3: 3{Environment.NewLine}";
+
+        actual.Should().BeEquivalentTo(expected);
+    }
+
+    [TestMethod]
+    public void CanonicalizeShouldConvertMultilineStringToPreferredFormat()
+    {
+        var initial = @"value: >
+  multiline
+
+  string";
+        var expected = @"value: |-
+  multiline
+  string
+";
+        var actual = new YamlPocoConverter().Canonicalize<StringObject>(initial);
+        actual.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public void SerializerShouldQuoteSpecialStringValues()
+    {
+        // Most strings do not need quotes, but values which could be treated as literals of another type
+        // such as numbers, "true", "false", "null", "no" etc can cause problems when not quoted
+        var obj = new StringListObject { List = new List<string> { "no quotes needed", "1", "3.14", "false", "true", "null", "no" } };
+        var expected = @"list:
+- no quotes needed
+- ""1""
+- ""3.14""
+- ""false""
+- ""true""
+- ""null""
+- ""no""
+";
+        var actual = new YamlPocoConverter().Serializer.Serialize(obj);
+        actual.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public void DeserializerShouldHandleSpecialValuesAsStringsEvenWithoutQuotes()
+    {
+        var withQuotes = @"list:
+- no quotes needed
+- ""1""
+- ""3.14""
+- ""false""
+- ""true""
+- ""no""
+";
+        var withoutQuotes = @"list:
+- no quotes needed
+- 1
+- 3.14
+- false
+- true
+- no
+";
+        var yamlConverter = new YamlPocoConverter();
+        var actualFromQuoted = yamlConverter.Deserializer.Deserialize<StringListObject>(withQuotes);
+        var actualFromNonQuoted = yamlConverter.Deserializer.Deserialize<StringListObject>(withoutQuotes);
+
+        // Raw deserialization of non-quoted numbers or special values like true/false/no lead to
+        // object values as numbers or bools, but the Deserializer should figure out the correct
+        // type (string here) without the quotes, as we provided it with the expected type.
+        // Note that null (sans quotes) cannot be read as a string, as null is a valid value. Those would
+        // require quotes "null" to deserialize as a string value
+        actualFromQuoted.List.Should().BeEquivalentTo(actualFromNonQuoted.List);
+    }
+
+    [TestMethod]
+    public void DuplicateKeysDefinedOnTypeThrowsException()
+    {
+        var duplicateKeys = "collision: foo\ncollision: bar";
+        var converter = new YamlPocoConverter();
+        Action deserialize = () => converter.Deserializer.Deserialize<DuplicateKeyObject>(duplicateKeys);
+
+        deserialize.Should().Throw<YamlException>().WithMessage("Multiple properties with the name/alias 'collision' already exists on type*");
+    }
+
+    [TestMethod]
+    public void DuplicateKeysTargetingSamePropertyThrowsException()
+    {
+        var duplicateKeys = "value: foo\nvalue: bar";
+        var converter = new YamlPocoConverter();
+        Action deserialize = () => converter.Deserializer.Deserialize<StringObject>(duplicateKeys);
+
+        deserialize.Should().Throw<YamlException>().WithMessage("Encountered duplicate key value");
+    }
+
+    [TestMethod]
+    public void DefaultValuesSerializationTest()
+    {
+        var obj = new DefaultValuesObject
+        {
+            Foo = null, // DefaultValuesHandling.OmitDefaults, should not be serialized
+            Bar = "bar", // DefaultValuesHandling.OmitDefaults, and DefaultValue = bar, should not be serialized
+            Baz = null, // DefaultValuesHandling.Preserve, should serialize as empty
+        };
+        var expected = $"baz: {Environment.NewLine}";
+
+        var actual = new YamlPocoConverter().Serializer.Serialize(obj);
+        actual.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public void DefaultValuesDeserializationTest()
+    {
+        var yaml = $"baz: {Environment.NewLine}";
+        var actual = new YamlPocoConverter().Deserializer.Deserialize<DefaultValuesObject>(yaml);
+        actual.Foo.Should().BeNull();
+        actual.Bar.Should().Be("bar");
+        actual.Baz.Should().BeNull();
+    }
+}

--- a/src/PAModelTests/Yaml2SerializerTests/YamlPocoConverterTests.cs
+++ b/src/PAModelTests/Yaml2SerializerTests/YamlPocoConverterTests.cs
@@ -163,4 +163,28 @@ arg3: 5
         actual.Bar.Should().Be("bar");
         actual.Baz.Should().BeNull();
     }
+
+    [TestMethod]
+    public void YamlIgnorePreventsSerialization()
+    {
+        var obj = new IgnoreSomePropertiesObject
+        {
+            IncludeMe = "foo",
+            IgnoreMe = "bar"
+        };
+        var expected = $"includeMe: foo{Environment.NewLine}";
+
+        var actual = new YamlPocoConverter().Serializer.Serialize(obj);
+        actual.Should().Be(expected);
+    }
+
+    [TestMethod]
+    public void YamlIgnorePreventsDeserialization()
+    {
+        var yaml = @"includeMe: foo
+ignoreMe: bar
+";
+        Action deserialize = () => new YamlPocoConverter().Deserializer.Deserialize<IgnoreSomePropertiesObject>(yaml);
+        deserialize.Should().Throw<YamlException>().WithMessage("Property 'ignoreMe' not found on type *");
+    }
 }

--- a/src/PAModelTests/Yaml2SerializerTests/YamlPocoTypes/DefaultValuesObject.cs
+++ b/src/PAModelTests/Yaml2SerializerTests/YamlPocoTypes/DefaultValuesObject.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel;
+using YamlDotNet.Serialization;
+
+namespace PAModelTests.Yaml2SerializerTests.YamlPocoTypes;
+
+public class DefaultValuesObject
+{
+    public DefaultValuesObject()
+    {
+        // Note that default value handling is used for serialization, but not deserialization.
+        // We need to initialize that value ourselves in the constructor or property init syntax
+        Bar = "bar";
+    }
+
+    [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+    public string Foo { get; set; }
+
+    [YamlMember(DefaultValuesHandling = DefaultValuesHandling.OmitDefaults)]
+    [DefaultValue("bar")]
+    public string Bar { get; set; }
+
+    [YamlMember(DefaultValuesHandling = DefaultValuesHandling.Preserve)]
+    public string Baz { get; set; }
+}

--- a/src/PAModelTests/Yaml2SerializerTests/YamlPocoTypes/DuplicateKeyObject.cs
+++ b/src/PAModelTests/Yaml2SerializerTests/YamlPocoTypes/DuplicateKeyObject.cs
@@ -1,0 +1,12 @@
+using YamlDotNet.Serialization;
+
+namespace PAModelTests.Yaml2SerializerTests.YamlPocoTypes;
+
+public class DuplicateKeyObject
+{
+    [YamlMember(Alias = "collision", Description = "asdf")]
+    public string Arg1 { get; set; }
+
+    [YamlMember(Alias = "collision")]
+    public string Arg2 { get; set; }
+}

--- a/src/PAModelTests/Yaml2SerializerTests/YamlPocoTypes/DuplicateKeyObject.cs
+++ b/src/PAModelTests/Yaml2SerializerTests/YamlPocoTypes/DuplicateKeyObject.cs
@@ -4,7 +4,7 @@ namespace PAModelTests.Yaml2SerializerTests.YamlPocoTypes;
 
 public class DuplicateKeyObject
 {
-    [YamlMember(Alias = "collision", Description = "asdf")]
+    [YamlMember(Alias = "collision")]
     public string Arg1 { get; set; }
 
     [YamlMember(Alias = "collision")]

--- a/src/PAModelTests/Yaml2SerializerTests/YamlPocoTypes/IgnoreSomePropertiesObject.cs
+++ b/src/PAModelTests/Yaml2SerializerTests/YamlPocoTypes/IgnoreSomePropertiesObject.cs
@@ -1,0 +1,11 @@
+using YamlDotNet.Serialization;
+
+namespace PAModelTests.Yaml2SerializerTests.YamlPocoTypes;
+
+public class IgnoreSomePropertiesObject
+{
+    public string IncludeMe { get; set; }
+
+    [YamlIgnore]
+    public string IgnoreMe { get; set; }
+}

--- a/src/PAModelTests/Yaml2SerializerTests/YamlPocoTypes/NumberObject.cs
+++ b/src/PAModelTests/Yaml2SerializerTests/YamlPocoTypes/NumberObject.cs
@@ -1,0 +1,7 @@
+namespace PAModelTests.Yaml2SerializerTests.YamlPocoTypes;
+
+public class NumberObject
+{
+    public int Integer { get; set; }
+    public double Double { get; set; }
+}

--- a/src/PAModelTests/Yaml2SerializerTests/YamlPocoTypes/OrderedObject.cs
+++ b/src/PAModelTests/Yaml2SerializerTests/YamlPocoTypes/OrderedObject.cs
@@ -1,0 +1,15 @@
+using YamlDotNet.Serialization;
+
+namespace PAModelTests.Yaml2SerializerTests.YamlPocoTypes;
+
+public class OrderedObject
+{
+    [YamlMember(Order = 3)]
+    public int Arg3 { get; set; }
+
+    [YamlMember(Order = 2)]
+    public string Arg2 { get; set; }
+
+    [YamlMember(Order = 1)]
+    public bool Arg1 { get; set; }
+}

--- a/src/PAModelTests/Yaml2SerializerTests/YamlPocoTypes/StringListObject.cs
+++ b/src/PAModelTests/Yaml2SerializerTests/YamlPocoTypes/StringListObject.cs
@@ -1,0 +1,6 @@
+namespace PAModelTests.Yaml2SerializerTests.YamlPocoTypes;
+
+public class StringListObject
+{
+    public IList<string> List { get; set; }
+}

--- a/src/PAModelTests/Yaml2SerializerTests/YamlPocoTypes/StringObject.cs
+++ b/src/PAModelTests/Yaml2SerializerTests/YamlPocoTypes/StringObject.cs
@@ -1,0 +1,6 @@
+namespace PAModelTests.Yaml2SerializerTests.YamlPocoTypes;
+
+public class StringObject
+{
+    public string Value { get; set; }
+}


### PR DESCRIPTION
Proof of concept for using YamlDotNet for our serialization & deserialization needs.
- Handles writing multiline strings in our preffered `|` style instead of YamlDotNet's default `>` via `MultilineStyleEmitter.cs`
- Serialized YAML writes properties in the order defined by `[YamlMember(Order = N)]`
- Allows overriding default proper names via `[YamlMember(Alias = "example")]`
- Prevent serialization and deserialization of specific properties with `[YamlIgnore]`
- Serialization includes quotes on values when those values could be mistaken for another type
  - strings containing numbers like `1` serialize to `"1"`
  - strings with bools or special values like `true`/`false`/`no`/`null` serialize to `"true"`/`"false"`/`"no"`/`"null"`
- Deserialization uses provided type information, so typically resolves ambiguous types by using the provided type.
  - `.Deserialize<string>(...)` or deserializing an object with string or string collection properties will correctly handle reading `1`, `true`, `false`, `no` without quotes as strings
  -  Note: `.Deserialize<string>(...)` will however read `null` without quotes as `null`, as that is a valid value for the destination `string` type
- Deserialization a polymorphic collection is doable, but requires more work.  It is not currently included in the `YamlPocoConverter.cs`, but examples are provided with tests in `ControlInfoPoC.cs`
  - E.g., deserializing a `List<Control>` containing objects of inheriting types like `Button` or `TextInput` need to contain a mapping type line (`ControlType` in the included PoC), and the deserializer needs to be provided with that key-to-type mapping
- Versioning of objects can also be handled by that same mapping, also included in the `ControlInfoPoC.cs` example
