### PR TITLE
ZIndex handling - Controls should be serialized in ZIndex order, and the property itself should be ommited from the YAML

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -588,3 +588,4 @@ csharp_style_prefer_not_pattern = true:suggestion
 csharp_style_prefer_extended_property_pattern = true:suggestion
 dotnet_diagnostic.CA1802.severity = error
 dotnet_diagnostic.CA1805.severity = error
+dotnet_diagnostic.IDE0061.severity = none

--- a/.version/PipelineAssemblyInfo.cs
+++ b/.version/PipelineAssemblyInfo.cs
@@ -1,6 +1,5 @@
-// <copyright company="Microsoft">
-// Copyright (c) Microsoft. All rights reserved.
-// </copyright>
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
 
 // This is pipeline generated file. Do not modify. This will be replaced with the actual versions in the actual Pipeline.
 using System.Reflection;

--- a/src/Persistence.Tests/Yaml/DeserializerValidTests.cs
+++ b/src/Persistence.Tests/Yaml/DeserializerValidTests.cs
@@ -92,16 +92,16 @@ public class DeserializerValidTests : TestBase
         sut.Children![0].Name.Should().Be("Label1");
         sut.Children![0].TemplateId.Should().Be("http://microsoft.com/appmagic/text");
         sut.Children![0].Properties.Should().NotBeNull()
-                .And.HaveCount(1)
-                .And.ContainKey("Text");
+                .And.HaveCount(2)
+                .And.ContainKeys("Text", "ZIndex");
         sut.Children![0].Properties["Text"].Value.Should().Be("lorem ipsum");
 
         sut.Children![1].Should().BeOfType<BuiltInControl>();
         sut.Children![1].Name.Should().Be("Button1");
         sut.Children![1].TemplateId.Should().Be("http://microsoft.com/appmagic/button");
         sut.Children![1].Properties.Should().NotBeNull()
-                .And.HaveCount(3)
-                .And.ContainKeys("Text", "X", "Y");
+                .And.HaveCount(4)
+                .And.ContainKeys("Text", "X", "Y", "ZIndex");
         sut.Children![1].Properties["Text"].Value.Should().Be("click me");
         sut.Children![1].Properties["X"].Value.Should().Be("100");
         sut.Children![1].Properties["Y"].Value.Should().Be("200");

--- a/src/Persistence.Tests/Yaml/DeserializerValidTests.cs
+++ b/src/Persistence.Tests/Yaml/DeserializerValidTests.cs
@@ -93,7 +93,7 @@ public class DeserializerValidTests : TestBase
         sut.Children![0].TemplateId.Should().Be("http://microsoft.com/appmagic/text");
         sut.Children![0].Properties.Should().NotBeNull()
                 .And.HaveCount(2)
-                .And.ContainKeys("Text", "ZIndex");
+                .And.ContainKeys("Text", PropertyNames.ZIndex);
         sut.Children![0].Properties["Text"].Value.Should().Be("lorem ipsum");
 
         sut.Children![1].Should().BeOfType<BuiltInControl>();
@@ -101,7 +101,7 @@ public class DeserializerValidTests : TestBase
         sut.Children![1].TemplateId.Should().Be("http://microsoft.com/appmagic/button");
         sut.Children![1].Properties.Should().NotBeNull()
                 .And.HaveCount(4)
-                .And.ContainKeys("Text", "X", "Y", "ZIndex");
+                .And.ContainKeys("Text", "X", "Y", PropertyNames.ZIndex);
         sut.Children![1].Properties["Text"].Value.Should().Be("click me");
         sut.Children![1].Properties["X"].Value.Should().Be("100");
         sut.Children![1].Properties["Y"].Value.Should().Be("200");
@@ -152,7 +152,7 @@ public class DeserializerValidTests : TestBase
     [TestMethod]
     [DataRow(@"_TestData/ValidYaml/Screen-with-controls.fx.yaml", typeof(Screen), "http://microsoft.com/appmagic/screen", "Screen 1", 2, 2)]
     [DataRow(@"_TestData/ValidYaml/Screen-with-name.fx.yaml", typeof(Screen), "http://microsoft.com/appmagic/screen", "My Power Apps Screen", 0, 0)]
-    [DataRow(@"_TestData/ValidYaml/Control-with-custom-template.yaml", typeof(CustomControl), "http://localhost/#customcontrol", "My Power Apps Custom Control", 0, 9)]
+    [DataRow(@"_TestData/ValidYaml/Control-with-custom-template.yaml", typeof(CustomControl), "http://localhost/#customcontrol", "My Power Apps Custom Control", 0, 8)]
     [DataRow(@"_TestData/ValidYaml/Screen/with-template-id.fx.yaml", typeof(Screen), "http://microsoft.com/appmagic/screen", "Hello", 0, 0)]
     [DataRow(@"_TestData/ValidYaml/Screen/with-template-name.fx.yaml", typeof(Screen), "http://microsoft.com/appmagic/screen", "Hello", 0, 0)]
     [DataRow(@"_TestData/ValidYaml/BuiltInControl/with-template.yaml", typeof(BuiltInControl), "http://microsoft.com/appmagic/button", "button with template", 0, 1)]

--- a/src/Persistence.Tests/Yaml/RoundTripTests.cs
+++ b/src/Persistence.Tests/Yaml/RoundTripTests.cs
@@ -24,7 +24,7 @@ public class RoundTripTests : TestBase
     [DataRow(@"_TestData/ValidYaml/Screen/with-multiline-properties.fx.yaml", typeof(Screen), "http://microsoft.com/appmagic/screen",
         "Screen with two multiline properties", 2, 0)]
     [DataRow(@"_TestData/ValidYaml/Control-with-custom-template.yaml", typeof(CustomControl), "http://localhost/#customcontrol",
-        "My Power Apps Custom Control", 9, 0)]
+        "My Power Apps Custom Control", 8, 0)]
     [DataRow(@"_TestData/ValidYaml/BuiltInControl1.yaml", typeof(BuiltInControl), "http://microsoft.com/appmagic/powercontrol/PowerApps_CoreControls_ButtonCanvas",
         "BuiltIn Control1", 1, 0)]
     public void RoundTrip_ValidYaml(string path, Type rootType, string expectedTemplateId, string expectedName, int expectedPropsCount, int expectedControlCount)

--- a/src/Persistence.Tests/Yaml/ZIndexOrderingTests.cs
+++ b/src/Persistence.Tests/Yaml/ZIndexOrderingTests.cs
@@ -1,0 +1,64 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.PowerPlatform.PowerApps.Persistence.Models;
+using Microsoft.PowerPlatform.PowerApps.Persistence.Yaml;
+
+namespace Persistence.Tests.Yaml;
+
+[TestClass]
+public class ZIndexOrderingTests : TestBase
+{
+    [TestMethod]
+    public void SerializedChildrenInZOrder()
+    {
+        var graph = ControlFactory.CreateScreen("Screen1",
+            properties: new() { { "Text", "\"I am a screen\"" }, },
+            children: new Control[]
+            {
+                MakeLabelWithZIndex(1),
+                MakeLabelWithZIndex(3),
+                MakeLabelWithZIndex(2),
+                MakeLabelWithZIndex(5),
+                MakeLabelWithZIndex(4),
+            }
+        );
+
+        var serializer = ServiceProvider.GetRequiredService<IYamlSerializationFactory>().CreateSerializer();
+
+        var sut = serializer.Serialize(graph);
+        var expected = File.ReadAllText(@"_TestData/ValidYaml/ZIndexOrdering/Screen-with-sorted-children.fx.yaml");
+        sut.Should().BeEquivalentTo(expected);
+    }
+
+    [TestMethod]
+    public void DeserializeChildrenShouldHaveMatchingZIndexProperty()
+    {
+        var deserializer = ServiceProvider.GetRequiredService<IYamlSerializationFactory>().CreateDeserializer();
+
+        using var yamlStream = File.OpenRead(@"_TestData/ValidYaml/ZIndexOrdering/Screen-with-sorted-children.fx.yaml");
+        using var yamlReader = new StreamReader(yamlStream);
+
+        var sut = deserializer.Deserialize<Screen>(yamlReader);
+
+        sut.Children.Should()
+            .HaveCount(5)
+            .And.BeEquivalentTo(new[]
+            {
+                MakeLabelWithZIndex(5),
+                MakeLabelWithZIndex(4),
+                MakeLabelWithZIndex(3),
+                MakeLabelWithZIndex(2),
+                MakeLabelWithZIndex(1),
+            });
+    }
+
+    private Control MakeLabelWithZIndex(int i)
+    {
+        return ControlFactory.Create($"Label{i}", template: "text",
+            new Dictionary<string, ControlPropertyValue>()
+            {
+                { "ZIndex", new() {Value = i.ToString()} },
+            });
+    }
+}

--- a/src/Persistence.Tests/Yaml/ZIndexOrderingTests.cs
+++ b/src/Persistence.Tests/Yaml/ZIndexOrderingTests.cs
@@ -58,7 +58,7 @@ public class ZIndexOrderingTests : TestBase
         return ControlFactory.Create($"Label{i}", template: "text",
             new Dictionary<string, ControlPropertyValue>()
             {
-                { "ZIndex", new() {Value = i.ToString()} },
+                { PropertyNames.ZIndex, new() {Value = i.ToString()} },
             });
     }
 }

--- a/src/Persistence.Tests/_TestData/AppsWithYaml/HelloWorld.msapp/Src/HelloScreen.fx.yaml
+++ b/src/Persistence.Tests/_TestData/AppsWithYaml/HelloWorld.msapp/Src/HelloScreen.fx.yaml
@@ -11,4 +11,3 @@ Children:
     Size: 100
     Text: Hello Power Apps!
     Width: 1366
-    ZIndex: 1

--- a/src/Persistence.Tests/_TestData/ValidYaml/Control-with-custom-template.yaml
+++ b/src/Persistence.Tests/_TestData/ValidYaml/Control-with-custom-template.yaml
@@ -9,4 +9,3 @@ Properties:
   Width: 560
   X: 30
   Y: 308
-  ZIndex: 2

--- a/src/Persistence.Tests/_TestData/ValidYaml/Screen-with-controls-as-temples.fx.yaml
+++ b/src/Persistence.Tests/_TestData/ValidYaml/Screen-with-controls-as-temples.fx.yaml
@@ -15,7 +15,6 @@ Children:
     Width: 560
     X: 30
     Y: 308
-    ZIndex: 2
 - Button:
   Name: Button with no template
   Properties:
@@ -31,4 +30,3 @@ Children:
     Width: 280
     X: 170
     Y: 464
-    ZIndex: 1

--- a/src/Persistence.Tests/_TestData/ValidYaml/Screen-with-controls.fx.yaml
+++ b/src/Persistence.Tests/_TestData/ValidYaml/Screen-with-controls.fx.yaml
@@ -15,7 +15,6 @@ Children:
     Width: 560
     X: 30
     Y: 308
-    ZIndex: 2
 - Button: 
   Name: Built-in Button
   Properties:
@@ -31,4 +30,3 @@ Children:
     Width: 280
     X: 170
     Y: 464
-    ZIndex: 1

--- a/src/Persistence.Tests/_TestData/ValidYaml/ZIndexOrdering/Screen-with-sorted-children.fx.yaml
+++ b/src/Persistence.Tests/_TestData/ValidYaml/ZIndexOrdering/Screen-with-sorted-children.fx.yaml
@@ -1,0 +1,15 @@
+Screen: 
+Name: Screen1
+Properties:
+  Text: I am a screen
+Children:
+- Text: 
+  Name: Label5
+- Text: 
+  Name: Label4
+- Text: 
+  Name: Label3
+- Text: 
+  Name: Label2
+- Text: 
+  Name: Label1

--- a/src/Persistence/Collections/ControlPropertiesCollection.cs
+++ b/src/Persistence/Collections/ControlPropertiesCollection.cs
@@ -79,6 +79,14 @@ public class ControlPropertiesCollection : IReadOnlyDictionary<string, ControlPr
         _properties.Add(keyValue.Item1, new ControlPropertyValue(keyValue.Item2));
     }
 
+    internal void Set(string key, ControlPropertyValue value)
+    {
+        if (string.IsNullOrWhiteSpace(key))
+            throw new ArgumentNullException(nameof(key));
+
+        _properties[key] = value;
+    }
+
     public void Remove(string key)
     {
         _properties.Remove(key);

--- a/src/Persistence/Models/Control.cs
+++ b/src/Persistence/Models/Control.cs
@@ -83,7 +83,7 @@ public abstract record Control
         for (var i = 0; i < Children.Length; i++)
         {
             var zIndex = Children.Length - i;
-            Children[i].Properties.Set("ZIndex", new(zIndex.ToString(CultureInfo.InvariantCulture)) { IsFormula = false });
+            Children[i].Properties.Set(PropertyNames.ZIndex, new(zIndex.ToString(CultureInfo.InvariantCulture)) { IsFormula = false });
         }
     }
 
@@ -102,13 +102,13 @@ public abstract record Control
             .ToArray();
 
         static int getZIndex(Control child) =>
-            child.Properties.TryGetValue("ZIndex", out var prop) && int.TryParse(prop.Value, out var zIndex)
+            child.Properties.TryGetValue(PropertyNames.ZIndex, out var prop) && int.TryParse(prop.Value, out var zIndex)
                 ? zIndex
                 : int.MaxValue;
 
         static Control removeZIndexProperty(Control child)
         {
-            child.Properties.Remove("ZIndex");
+            child.Properties.Remove(PropertyNames.ZIndex);
             return child;
         }
     }

--- a/src/Persistence/Yaml/PropertyNames.cs
+++ b/src/Persistence/Yaml/PropertyNames.cs
@@ -1,0 +1,9 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.Yaml;
+
+public static class PropertyNames
+{
+    public const string ZIndex = "ZIndex";
+}

--- a/src/Persistence/Yaml/YamlSerializationFactory.cs
+++ b/src/Persistence/Yaml/YamlSerializationFactory.cs
@@ -46,7 +46,7 @@ public class YamlSerializationFactory : IYamlSerializationFactory
         options ??= YamlDeserializerOptions.Default;
 
         var yamlDeserializer = new DeserializerBuilder()
-           .WithObjectFactory(new ControlObjectFactory(_controlTemplateStore, _controlFactory))
+            .WithObjectFactory(new ControlObjectFactory(_controlTemplateStore, _controlFactory))
             .IgnoreUnmatchedProperties()
             .WithTypeInspector(inner => new ControlTypeInspector(inner, _controlTemplateStore))
             .WithTypeDiscriminatingNodeDeserializer(o =>
@@ -54,7 +54,7 @@ public class YamlSerializationFactory : IYamlSerializationFactory
                 o.AddTypeDiscriminator(new ControlTypeDiscriminator(_controlTemplateStore));
             })
             .WithTypeConverter(new ControlPropertiesCollectionConverter() { IsTextFirst = options.IsTextFirst })
-           .Build();
+            .Build();
 
         return yamlDeserializer;
     }


### PR DESCRIPTION
When serializing, child controls will be sorted by their ZIndex property and the property itself will be omitted from the yaml output.  When deserializing, the ZIndex property will be added to each control based on the order found in the yaml array.