### PR TITLE
Updated argument format for Controls in AppWriter

### DIFF
--- a/samples/Test.AppWriter/ExampleAppGenerator.cs
+++ b/samples/Test.AppWriter/ExampleAppGenerator.cs
@@ -9,18 +9,6 @@ namespace Test.AppWriter;
 
 internal class ExampleAppGenerator
 {
-    public static List<(string, string)> ParseControlsInfo(string[] controlInfos)
-    {
-        var tuples = new List<(string, string)>();
-
-        for (var i = 0; i < controlInfos.Length; i += 2)
-        {
-            tuples.Add((controlInfos[i], controlInfos[i + 1]));
-        }
-
-        return tuples;
-    }
-
     // This produces a simple example app including the specified number of screens and a few generic controls
     // This is intended for testing purposes only
     public static App GetExampleApp(IServiceProvider provider, string appName, int numScreens)
@@ -93,7 +81,7 @@ internal class ExampleAppGenerator
     }
 
     // produce a specified app based on commandline input
-    public static App CreateApp(IServiceProvider provider, string appName, int numScreens, List<(string, string)> controls)
+    public static App CreateApp(IServiceProvider provider, string appName, int numScreens, string[] controls)
     {
         var controlFactory = provider.GetRequiredService<IControlFactory>();
 
@@ -104,7 +92,7 @@ internal class ExampleAppGenerator
             var childList = new List<Control>();
             foreach (var control in controls)
             {
-                childList.Add(controlFactory.Create(control.Item1, template: control.Item2,
+                childList.Add(controlFactory.Create(control + childList.Count.ToString(), template: control,
                     properties: new()
                 ));
             }

--- a/samples/Test.AppWriter/Program.cs
+++ b/samples/Test.AppWriter/Program.cs
@@ -76,7 +76,7 @@ internal class Program
         msapp.App = interactive
             ? InteractiveAppGenerator.GenerateApp(provider, Path.GetFileNameWithoutExtension(fullPathToMsApp))
             : ExampleAppGenerator.CreateApp(provider, Path.GetFileNameWithoutExtension(fullPathToMsApp),
-                numScreens, ExampleAppGenerator.ParseControlsInfo(controlsinfo));
+                numScreens, controlsinfo);
 
         // Output the MSApp to the path provided
         msapp.Save();
@@ -117,12 +117,9 @@ internal class Program
                 result.ErrorMessage = "Number of screens must be greater than 0";
             }
         });
-        //var screenNamesOption = new Option<string>(
-        //    name: "--screennames"
-        //    );
         var controlsOptions = new Option<string[]>(
             name: "--controls",
-            description: "(list of string) A list of control name and template pairs (i.e. mybutton Button labelname Label [controlname Template]...)")
+            description: "(list of string) A list of control templates (i.e. Button Label [Template]...)")
         { AllowMultipleArgumentsPerToken = true };
 
         var rootCommand = new RootCommand("Test Writer for MSApp files.");


### PR DESCRIPTION
If this is related to an issue open in GitHub, please link it to this ticket and put the URL here.

## Problem

What is the issue we are attempting to solve?

## Solution

What are we doing to solve this issue?

## Changes

- **Changed the expected format for the --controls argument to the Test.AppWriter commandline app, now it expects only a list of templates and will auto-generate placeholder names**

## Validation

- How did you verify that this issue is truly fixed?
