### PR TITLE
Add place for Settings as a child of App

### DIFF
--- a/src/Persistence.Tests/Yaml/DeserializerValidTests.cs
+++ b/src/Persistence.Tests/Yaml/DeserializerValidTests.cs
@@ -199,6 +199,27 @@ public class DeserializerValidTests : TestBase
         app.Properties.Should().NotBeNull().And.HaveCount(propertiesCount);
     }
 
+
+    [TestMethod]
+    [DataRow(@"_TestData/ValidYaml/App-with-settings.pa.yaml", "Test App Name", 1)]
+    public void Deserialize_App_WithSettings_ShouldSucceed(string path, string expectedName, int propertiesCount)
+    {
+        // Arrange
+        var deserializer = ServiceProvider.GetRequiredService<IYamlSerializationFactory>().CreateDeserializer();
+        using var yamlStream = File.OpenRead(path);
+        using var yamlReader = new StreamReader(yamlStream);
+
+        // Act
+        var controlObj = deserializer.Deserialize(yamlReader);
+        controlObj.Should().BeAssignableTo<App>();
+        var app = controlObj as App;
+
+        app!.Settings.Should().NotBeNull();
+        app!.Settings!.Name.Should().NotBeNull().And.Be(expectedName);
+        app!.Settings!.Layout.Should().Be(Settings.AppLayout.Landscape);
+        app.Properties.Should().NotBeNull().And.HaveCount(propertiesCount);
+    }
+
     [TestMethod]
     [DataRow(@"_TestData/ValidYaml/Screen-with-unmatched-field.pa.yaml")]
     public void Deserialize_ShouldIgnoreUnmatchedProperties(string path)

--- a/src/Persistence.Tests/_TestData/ValidYaml/App-with-settings.pa.yaml
+++ b/src/Persistence.Tests/_TestData/ValidYaml/App-with-settings.pa.yaml
@@ -1,0 +1,6 @@
+App: 
+Properties:
+  OnStart: =Set(foo, 123)
+Settings:
+  Name: Test App Name
+  Layout: Landscape

--- a/src/Persistence/Models/App.cs
+++ b/src/Persistence/Models/App.cs
@@ -28,4 +28,6 @@ public record App : Control
 
     [YamlIgnore]
     public IList<Screen> Screens { get; set; } = new List<Screen>();
+
+    public Settings? Settings { get; init; }
 }

--- a/src/Persistence/Models/Settings.cs
+++ b/src/Persistence/Models/Settings.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.Models;
+
+public record Settings
+{
+    public enum AppLayout
+    {
+        Portrait,
+        Landscape
+    }
+
+    public string Name { get; init; } = string.Empty;
+    public AppLayout Layout { get; init; }
+}


### PR DESCRIPTION
For single-yaml load, we'll need a way to represent some app characteristics, like app name and layout. This is not yet intended for the load/save path, however, it should be able to converge long term. 