### PR TITLE
Improved error reporting for invalid properties

### DIFF
--- a/src/Persistence.Tests/_TestData/InvalidYaml/screen-with-not-valid-control.pa.yaml
+++ b/src/Persistence.Tests/_TestData/InvalidYaml/screen-with-not-valid-control.pa.yaml
@@ -1,0 +1,11 @@
+Screens:
+- Screen: 
+  Name: Screen1
+  Properties:
+    LoadingSpinnerColor: =RGBA(56, 96, 178, 1)
+  Children:
+  - NoValidControl: 
+    Name: Foo
+    Properties:
+      BorderColor: =RGBA(0, 18, 107, 1)
+      BorderThickness: =2

--- a/src/Persistence/Yaml/ControlObjectFactory.cs
+++ b/src/Persistence/Yaml/ControlObjectFactory.cs
@@ -30,6 +30,12 @@ public class ControlObjectFactory : IObjectFactory
             return _controlFactory.Create(controlTemplate.Name, controlTemplate);
         }
 
+        // Control is abstract, so we'll try to create a concrete custom control type.
+        if (type == typeof(Control))
+        {
+            return _controlFactory.Create(nameof(CustomControl), nameof(Control));
+        }
+
         return _defaultObjectFactory.Create(type);
     }
 
@@ -76,7 +82,7 @@ public class ControlObjectFactory : IObjectFactory
 
     internal void RestoreNestedTemplates(Control control)
     {
-        if (control.Template.NestedTemplates == null)
+        if (control.Template == null || control.Template.NestedTemplates == null)
             return;
 
         foreach (var nestedTemplate in control.Template.NestedTemplates)

--- a/src/Persistence/Yaml/ControlTypeInspector.cs
+++ b/src/Persistence/Yaml/ControlTypeInspector.cs
@@ -65,6 +65,11 @@ internal class ControlTypeInspector : ITypeInspector
                 return new EmptyPropertyDescriptor(name);
         }
 
+        // For controls all properties have to match the list of expected properties.
+        // This improves error reporting via setting ignoreUnmatched to false.
+        if (type == typeof(Control))
+            return _innerTypeInspector.GetProperty(type, container, name, ignoreUnmatched: false);
+
         return _innerTypeInspector.GetProperty(type, container, name, ignoreUnmatched);
     }
 }


### PR DESCRIPTION
Expected error message:
Property 'NoValidControl' not found on type 'Microsoft.PowerPlatform.PowerApps.Persistence.Models.Control'.