### PR TITLE
Encapsulate the YamlDotNet serializer and deserializer

### DIFF
--- a/src/Persistence.Tests/Yaml/DeserializerInvalidTests.cs
+++ b/src/Persistence.Tests/Yaml/DeserializerInvalidTests.cs
@@ -28,7 +28,7 @@ public class DeserializerInvalidTests
             // Act
             try
             {
-                var result = deserializer.Deserialize(yamlReader);
+                var result = deserializer.Deserialize<Control>(yamlReader);
                 if (result is not Control)
                     throw new InvalidOperationException("Expected a control");
 

--- a/src/Persistence.Tests/Yaml/DeserializerValidTests.cs
+++ b/src/Persistence.Tests/Yaml/DeserializerValidTests.cs
@@ -167,7 +167,8 @@ public class DeserializerValidTests : TestBase
         using var yamlReader = new StreamReader(yamlStream);
 
         // Act
-        var controlObj = deserializer.Deserialize(yamlReader);
+        var method = typeof(IYamlDeserializer).GetMethod("Deserialize", new[] { typeof(TextReader) })!.MakeGenericMethod(expectedType);
+        var controlObj = method.Invoke(deserializer, new[] { yamlReader });
 
         // Assert
         controlObj.Should().BeAssignableTo(expectedType);
@@ -191,9 +192,8 @@ public class DeserializerValidTests : TestBase
         using var yamlReader = new StreamReader(yamlStream);
 
         // Act
-        var controlObj = deserializer.Deserialize(yamlReader);
-        controlObj.Should().BeAssignableTo<App>();
-        var app = controlObj as App;
+        var app = deserializer.Deserialize<App>(yamlReader);
+
         app!.Name.Should().NotBeNull().And.Be(expectedName);
         app.Children.Should().NotBeNull().And.HaveCount(controlCount);
         app.Properties.Should().NotBeNull().And.HaveCount(propertiesCount);
@@ -210,13 +210,11 @@ public class DeserializerValidTests : TestBase
         using var yamlReader = new StreamReader(yamlStream);
 
         // Act
-        var controlObj = deserializer.Deserialize(yamlReader);
-        controlObj.Should().BeAssignableTo<App>();
-        var app = controlObj as App;
+        var app = deserializer.Deserialize<App>(yamlReader);
 
-        app!.Settings.Should().NotBeNull();
-        app!.Settings!.Name.Should().NotBeNull().And.Be(expectedName);
-        app!.Settings!.Layout.Should().Be(Settings.AppLayout.Landscape);
+        app.Settings.Should().NotBeNull();
+        app.Settings!.Name.Should().NotBeNull().And.Be(expectedName);
+        app.Settings!.Layout.Should().Be(Settings.AppLayout.Landscape);
         app.Properties.Should().NotBeNull().And.HaveCount(propertiesCount);
     }
 
@@ -230,7 +228,7 @@ public class DeserializerValidTests : TestBase
         using var yamlReader = new StreamReader(yamlStream);
 
         // Act
-        var controlObj = deserializer.Deserialize(yamlReader);
+        var controlObj = deserializer.Deserialize<Screen>(yamlReader);
 
         // Assert
         controlObj.Should().NotBeNull();
@@ -280,11 +278,9 @@ public class DeserializerValidTests : TestBase
         using var yamlReader = new StreamReader(yamlStream);
 
         // Act
-        var result = deserializer.Deserialize(yamlReader);
-        result.Should().BeAssignableTo<Component>();
+        var component = deserializer.Deserialize<Component>(yamlReader);
 
         // Assert
-        var component = (Component)result!;
         component.Name.Should().Be(expectedName);
         component.Template.Should().NotBeNull();
         component.Template!.Name.Should().Be(expectedTemplateName);
@@ -306,11 +302,9 @@ public class DeserializerValidTests : TestBase
         using var yamlReader = new StreamReader(yamlStream);
 
         // Act
-        var result = deserializer.Deserialize(yamlReader);
-        result.Should().BeAssignableTo<Control>();
+        var control = deserializer.Deserialize<BuiltInControl>(yamlReader);
 
         // Assert
-        var control = (Control)result!;
         control.Name.Should().Be(expectedName);
         control.Template.Should().NotBeNull();
         control.Template!.Name.Should().Be(expectedTemplateName);

--- a/src/Persistence.Tests/Yaml/RoundTripTests.cs
+++ b/src/Persistence.Tests/Yaml/RoundTripTests.cs
@@ -35,7 +35,8 @@ public class RoundTripTests : TestBase
         using var yamlReader = new StreamReader(yamlStream);
 
         // Deserialize the yaml into an object.
-        var controlObj = deserializer.Deserialize(yamlReader);
+        var method = typeof(IYamlDeserializer).GetMethod("Deserialize", new[] { typeof(TextReader) })!.MakeGenericMethod(rootType);
+        var controlObj = method.Invoke(deserializer, new[] { yamlReader });
 
         // Validate the control.
         controlObj.Should().BeAssignableTo(rootType);
@@ -49,7 +50,7 @@ public class RoundTripTests : TestBase
             control.Children.Should().BeNull();
 
         // Serialize the object back into yaml.
-        var actualYaml = serializer.Serialize(controlObj).NormalizeNewlines();
+        var actualYaml = serializer.Serialize(control).NormalizeNewlines();
 
         // Assert that the yaml is the same.
         var expectedYaml = File.ReadAllText(path).NormalizeNewlines();

--- a/src/Persistence/MsApp/IMsappArchive.cs
+++ b/src/Persistence/MsApp/IMsappArchive.cs
@@ -20,7 +20,7 @@ public interface IMsappArchive : IDisposable
 
     Version DocVersion { get; }
 
-    T Deserialize<T>(string entryName, bool ensureRoundTrip = true);
+    T Deserialize<T>(string entryName, bool ensureRoundTrip = true) where T : Control;
 
     /// <summary>
     /// Saves control in the archive. Control can be App, Screen, or individual control.

--- a/src/Persistence/Yaml/IYamlDeserializer.cs
+++ b/src/Persistence/Yaml/IYamlDeserializer.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.PowerPlatform.PowerApps.Persistence.Models;
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.Yaml;
+
+public interface IYamlDeserializer
+{
+    public T Deserialize<T>(string yaml) where T : Control;
+
+    public T Deserialize<T>(TextReader reader) where T : Control;
+}

--- a/src/Persistence/Yaml/IYamlSerializationFactory.cs
+++ b/src/Persistence/Yaml/IYamlSerializationFactory.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using YamlDotNet.Serialization;
-
 namespace Microsoft.PowerPlatform.PowerApps.Persistence.Yaml;
 
 public interface IYamlSerializationFactory
 {
-    ISerializer CreateSerializer(bool? isTextFirst = null);
+    IYamlSerializer CreateSerializer(bool? isTextFirst = null);
 
-    IDeserializer CreateDeserializer(bool? isTextFirst = null);
+    IYamlDeserializer CreateDeserializer(bool? isTextFirst = null);
 }

--- a/src/Persistence/Yaml/IYamlSerializer.cs
+++ b/src/Persistence/Yaml/IYamlSerializer.cs
@@ -1,0 +1,13 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.PowerPlatform.PowerApps.Persistence.Models;
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.Yaml;
+
+public interface IYamlSerializer
+{
+    public string Serialize<T>(T graph) where T : Control;
+
+    public void Serialize<T>(TextWriter writer, T graph) where T : Control;
+}

--- a/src/Persistence/Yaml/YamlDeserializer.cs
+++ b/src/Persistence/Yaml/YamlDeserializer.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.PowerPlatform.PowerApps.Persistence.Models;
+using YamlDotNet.Serialization;
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.Yaml;
+
+public class YamlDeserializer : IYamlDeserializer
+{
+    private readonly IDeserializer _deserializer;
+
+    internal YamlDeserializer(IDeserializer deserializer)
+    {
+        _deserializer = deserializer ?? throw new ArgumentNullException(nameof(deserializer));
+    }
+
+    public T Deserialize<T>(string yaml) where T : Control
+    {
+        return _deserializer.Deserialize<T>(yaml);
+    }
+
+    public T Deserialize<T>(TextReader reader) where T : Control
+    {
+        return _deserializer.Deserialize<T>(reader);
+    }
+}

--- a/src/Persistence/Yaml/YamlSerializationFactory.cs
+++ b/src/Persistence/Yaml/YamlSerializationFactory.cs
@@ -17,12 +17,12 @@ public class YamlSerializationFactory : IYamlSerializationFactory
         _controlFactory = controlFactory ?? throw new ArgumentNullException(nameof(controlFactory));
     }
 
-    public ISerializer CreateSerializer(bool? isTextFirst = null)
+    public IYamlSerializer CreateSerializer(bool? isTextFirst = null)
     {
         return CreateSerializer(new YamlSerializerOptions { IsTextFirst = isTextFirst ?? YamlSerializerOptions.Default.IsTextFirst });
     }
 
-    public ISerializer CreateSerializer(YamlSerializerOptions? options)
+    public IYamlSerializer CreateSerializer(YamlSerializerOptions? options)
     {
         options ??= YamlSerializerOptions.Default;
 
@@ -33,15 +33,15 @@ public class YamlSerializationFactory : IYamlSerializationFactory
                 .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitEmptyCollections | DefaultValuesHandling.OmitNull)
            .Build();
 
-        return yamlSerializer;
+        return new YamlSerializer(yamlSerializer);
     }
 
-    public IDeserializer CreateDeserializer(bool? isTextFirst = null)
+    public IYamlDeserializer CreateDeserializer(bool? isTextFirst = null)
     {
         return CreateDeserializer(new YamlDeserializerOptions { IsTextFirst = isTextFirst ?? YamlDeserializerOptions.Default.IsTextFirst });
     }
 
-    public IDeserializer CreateDeserializer(YamlDeserializerOptions? options)
+    public IYamlDeserializer CreateDeserializer(YamlDeserializerOptions? options)
     {
         options ??= YamlDeserializerOptions.Default;
 
@@ -56,6 +56,6 @@ public class YamlSerializationFactory : IYamlSerializationFactory
             .WithTypeConverter(new ControlPropertiesCollectionConverter() { IsTextFirst = options.IsTextFirst })
             .Build();
 
-        return yamlDeserializer;
+        return new YamlDeserializer(yamlDeserializer);
     }
 }

--- a/src/Persistence/Yaml/YamlSerializer.cs
+++ b/src/Persistence/Yaml/YamlSerializer.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.PowerPlatform.PowerApps.Persistence.Models;
+using YamlDotNet.Serialization;
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.Yaml;
+
+public class YamlSerializer : IYamlSerializer
+{
+    private readonly ISerializer _serializer;
+
+    internal YamlSerializer(ISerializer serializer)
+    {
+        _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
+    }
+
+    public string Serialize<T>(T graph) where T : Control
+    {
+        return _serializer.Serialize(graph);
+    }
+
+    public void Serialize<T>(TextWriter writer, T graph) where T : Control
+    {
+        _serializer.Serialize(writer, graph);
+    }
+}


### PR DESCRIPTION
Encapsulate the YamlDotNet serializer and deserializer, giving us an extension point for Control specific conversions