### PR TITLE
Yaml Schema v2.2 OM - initial implementation

### DIFF
--- a/src/Persistence.Tests/Extensions/PersistenceFluentExtensions.cs
+++ b/src/Persistence.Tests/Extensions/PersistenceFluentExtensions.cs
@@ -1,0 +1,267 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using System.Text.RegularExpressions;
+using FluentAssertions.Execution;
+using FluentAssertions.Primitives;
+using YamlDotNet.RepresentationModel;
+
+namespace Persistence.Tests;
+
+/// <summary>
+/// Extensions for tests.
+/// </summary>
+internal static class PersistenceFluentExtensions
+{
+    /// <summary>
+    /// Asserts that the value is not null and gives the nullable assertion.
+    /// Will result in a FluentAssertionException if the value is null.
+    /// </summary>
+    public static void ShouldNotBeNull<T>([NotNull] this T? value)
+        where T : notnull
+    {
+        if (value is null)
+        {
+            value.Should().NotBeNull();
+            throw new InvalidOperationException("Should().NotBeNull() should have thrown.");
+        }
+    }
+
+    public static AndConstraint<TAssertions> BeYamlEquivalentTo<TAssertions>(this StringAssertions<TAssertions> assertions, string expectedYaml, string because = "", params object[] becauseArgs)
+        where TAssertions : StringAssertions<TAssertions>
+    {
+        _ = assertions ?? throw new ArgumentNullException(nameof(assertions));
+        _ = expectedYaml ?? throw new ArgumentNullException(nameof(expectedYaml));
+
+        assertions.Subject.ShouldNotBeNull();
+
+        var actualYamlStream = new YamlStream();
+        using (var actualTextReader = new StringReader(assertions.Subject))
+        {
+            actualYamlStream.Load(actualTextReader);
+        }
+
+        var expectedYamlStream = new YamlStream();
+        using (var expectedTextReader = new StringReader(expectedYaml))
+        {
+            expectedYamlStream.Load(expectedTextReader);
+        }
+
+        var context = nameof(actualYamlStream);
+        using (var scope = new AssertionScope(context))
+        {
+            CompareYamlStreams(actualYamlStream, expectedYamlStream, context);
+        }
+
+        //actualYamlStream.Should().BeEquivalentTo(expectedYamlStream, because, becauseArgs);
+
+        return new AndConstraint<TAssertions>((TAssertions)assertions);
+    }
+
+    private static void CompareYamlStreams(YamlStream actualYamlStream, YamlStream expectedYamlStream, string? contextBase = null)
+    {
+        contextBase ??= nameof(actualYamlStream);
+
+        foreach (var (docIdx, actualDoc, expectedDoc) in actualYamlStream.Documents.ZipWithIndex(expectedYamlStream.Documents))
+        {
+            var context = $"{contextBase}.{nameof(actualYamlStream.Documents)}[{docIdx}]";
+            CompareYamlTree(actualDoc, expectedDoc, context);
+        }
+
+        // Zip will only validate items that are in each list
+        actualYamlStream.Documents.Should().HaveSameCount(expectedYamlStream.Documents);
+    }
+
+    private static void CompareYamlTree(YamlDocument actualDoc, YamlDocument expectedDoc, string docContext)
+    {
+        docContext ??= nameof(actualDoc);
+
+        using (var scope = new AssertionScope(docContext))
+        {
+            var nodePath = string.Empty; // document root
+            CompareYamlTree(actualDoc.RootNode, expectedDoc.RootNode, nodePath);
+        }
+    }
+
+    private static void CompareYamlTree(YamlNode actualNode, YamlNode expectedNode, string nodePath)
+    {
+        const string BecauseFormat_PropertyName_NodePath_NodeStart = "(Node property: {0}, node path: '{1}', node location: {2})";
+
+        _ = actualNode ?? throw new ArgumentNullException(nameof(actualNode));
+        _ = expectedNode ?? throw new ArgumentNullException(nameof(expectedNode));
+        _ = nodePath ?? throw new ArgumentNullException(nameof(nodePath));
+
+        actualNode.NodeType.Should().Be(expectedNode.NodeType, BecauseFormat_PropertyName_NodePath_NodeStart, nameof(actualNode.NodeType), nodePath, actualNode.Start);
+
+        // TODO: add option of whether to compare the Style properties.
+
+        // Only compare the properties relevant to yaml equivalence
+        if (actualNode.NodeType == expectedNode.NodeType)
+        {
+            if (actualNode.NodeType == YamlNodeType.Scalar)
+            {
+                var actualScalar = (YamlScalarNode)actualNode;
+                var expectedScalar = (YamlScalarNode)expectedNode;
+
+                // Per YamlScalarNode's Equals implementation, the value and tag are the only properties that matter
+                actualScalar.Tag.Should().Be(expectedScalar.Tag, BecauseFormat_PropertyName_NodePath_NodeStart, nameof(actualNode.Tag), nodePath, actualNode.Start);
+                actualScalar.Value.Should().Be(expectedScalar.Value, BecauseFormat_PropertyName_NodePath_NodeStart, nameof(actualScalar.Value), nodePath, actualNode.Start);
+            }
+            else if (actualNode.NodeType == YamlNodeType.Sequence)
+            {
+                var actualSequence = (YamlSequenceNode)actualNode;
+                var expectedSequence = (YamlSequenceNode)expectedNode;
+
+                actualSequence.Tag.Should().Be(expectedSequence.Tag, BecauseFormat_PropertyName_NodePath_NodeStart, nameof(actualNode.Tag), nodePath, actualNode.Start);
+
+                foreach (var (childIdx, actualChild, expectedChild) in actualSequence.Children.ZipWithIndex(expectedSequence.Children))
+                {
+                    var childNodePath = $"{nodePath}[{childIdx}]";
+                    CompareYamlTree(actualChild, expectedChild, childNodePath);
+                }
+
+                // Zip will only validate items that are in each list
+                actualSequence.Children.Should().HaveSameCount(expectedSequence.Children, BecauseFormat_PropertyName_NodePath_NodeStart, nameof(actualSequence.Children), nodePath, actualNode.Start);
+            }
+            else if (actualNode.NodeType == YamlNodeType.Mapping)
+            {
+                var actualMapping = (YamlMappingNode)actualNode;
+                var expectedMapping = (YamlMappingNode)expectedNode;
+
+                actualMapping.Tag.Should().Be(expectedMapping.Tag, BecauseFormat_PropertyName_NodePath_NodeStart, nameof(actualNode.Tag), nodePath, actualNode.Start);
+
+                foreach (var (expectedKey, expectedValue) in expectedMapping.Children)
+                {
+                    // Note: technically, YAML mapping keys can be any yaml node type (e.g. scalar, sequence, mapping, etc.)
+                    // For now, we'll assume that the keys are always scalars and verify here:
+                    if (expectedKey.NodeType != YamlNodeType.Scalar)
+                    {
+                        throw new NotSupportedException($"Non-scalar key found in expected mapping at path '{nodePath}'.");
+                    }
+
+                    var actualValue = actualMapping[expectedKey];
+                    var valueNodePath = $"{nodePath}{((YamlScalarNode)expectedKey).ToBreadcrumbPathSegment()}";
+                    CompareYamlTree(actualValue, expectedValue, valueNodePath);
+                }
+
+                // Zip will only validate items that are in each list
+                actualMapping.Children.Should().HaveSameCount(expectedMapping.Children, BecauseFormat_PropertyName_NodePath_NodeStart, nameof(actualMapping.Children), nodePath, actualNode.Start);
+            }
+            else if (actualNode.NodeType == YamlNodeType.Alias)
+            {
+                // Note: YamlAliasNode is an internal class
+                actualNode.Anchor.Should().Be(expectedNode.Anchor, BecauseFormat_PropertyName_NodePath_NodeStart, nameof(actualNode.Anchor), nodePath, actualNode.Start);
+            }
+        }
+    }
+
+    private static readonly Regex RequiresEscapingRegex = new(@"[^a-zA-Z0-1_-]", RegexOptions.Compiled);
+
+    private static string ToBreadcrumbPathSegment(this YamlScalarNode node)
+    {
+        if (node.Value == null)
+        {
+            return "[~]";
+        }
+
+        if (RequiresEscapingRegex.IsMatch(node.Value))
+        {
+            return $"[\"{node.Value}\"]";
+        }
+
+        return $".{node.Value}";
+    }
+
+    //private static void CompareYamlNodesNonRecursive(IEnumerable<YamlNode> actualNodes, IEnumerable<YamlNode> expectedNodes, string? contextBase = null)
+    //{
+    //    contextBase ??= nameof(actualNodes);
+
+    //    actualNodes.Should().HaveSameCount(expectedNodes);
+
+    //    foreach (var (nodeIdx, actualNode, expectedNode) in actualNodes.ZipWithIndex(expectedNodes))
+    //    {
+    //        var context = $"{contextBase}[{nodeIdx}]";
+    //        using (var scope = new AssertionScope(context))
+    //            CompareYamlNodeNonRecursive(actualNode, expectedNode, context);
+    //    }
+    //}
+
+    //private static void CompareYamlNodeNonRecursive(YamlNode actualNode, YamlNode expectedNode, string? contextBase = null)
+    //{
+    //    contextBase ??= nameof(actualNode);
+
+    //    actualNode.NodeType.Should().Be(expectedNode.NodeType, contextBase);
+
+    //    // TODO: add option of whether to compare the Style properties.
+
+    //    // Only compare the properties relevant to yaml equivalence
+    //    if (actualNode.NodeType == expectedNode.NodeType)
+    //    {
+    //        if (actualNode.NodeType == YamlNodeType.Scalar)
+    //        {
+    //            var actualScalar = (YamlScalarNode)actualNode;
+    //            var expectedScalar = (YamlScalarNode)expectedNode;
+
+    //            // Per YamlScalarNode's Equals implementation, the value and tag are the only properties that matter
+    //            actualScalar.Tag.Should().Be(expectedScalar.Tag, contextBase);
+    //            actualScalar.Value.Should().Be(expectedScalar.Value, contextBase);
+    //        }
+    //        else if (actualNode.NodeType == YamlNodeType.Sequence)
+    //        {
+    //            var actualSequence = (YamlSequenceNode)actualNode;
+    //            var expectedSequence = (YamlSequenceNode)expectedNode;
+
+    //            actualSequence.Tag.Should().Be(expectedSequence.Tag, contextBase);
+    //            actualSequence.Children.Should().HaveSameCount(expectedSequence.Children, contextBase);
+    //        }
+    //        else if (actualNode.NodeType == YamlNodeType.Mapping)
+    //        {
+    //            var actualMapping = (YamlMappingNode)actualNode;
+    //            var expectedMapping = (YamlMappingNode)expectedNode;
+
+    //            actualMapping.Tag.Should().Be(expectedMapping.Tag, contextBase);
+    //            actualMapping.Children.Should().HaveSameCount(expectedMapping.Children, contextBase);
+    //        }
+    //        else if (actualNode.NodeType == YamlNodeType.Alias)
+    //        {
+    //            // Note: YamlAliasNode is an internal class
+    //            actualNode.Anchor.Should().Be(expectedNode.Anchor, contextBase);
+    //        }
+    //    }
+    //}
+
+    public static IEnumerable<(int Index, T1 Left, T2 Right)> ZipWithIndex<T1, T2>(this IEnumerable<T1> first, IEnumerable<T2> second)
+    {
+        _ = first ?? throw new ArgumentNullException(nameof(first));
+        _ = second ?? throw new ArgumentNullException(nameof(second));
+
+        return first.Zip(second)
+            .Select((item, index) => (index, item.First, item.Second));
+    }
+
+    public static void WriteTextWithLineNumbers(this TestContext testContext, string text, string? headerLine = null)
+    {
+        _ = testContext ?? throw new ArgumentNullException(nameof(testContext));
+
+        var sb = new StringBuilder();
+        if (headerLine is not null)
+        {
+            sb.AppendLine(headerLine);
+        }
+
+        StringReader reader = new(text);
+        var lineNumber = 1;
+        var line = reader.ReadLine();
+        while (line is not null)
+        {
+            sb.AppendLine($"{lineNumber,3}: {line}");
+            line = reader.ReadLine();
+            lineNumber++;
+        }
+
+        // We write all at one time to avoid any interleaving of lines from multiple threads
+        testContext.WriteLine(sb.ToString());
+    }
+}

--- a/src/Persistence.Tests/PaYaml/PaYamlSerializerTests.cs
+++ b/src/Persistence.Tests/PaYaml/PaYamlSerializerTests.cs
@@ -1,0 +1,127 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml;
+using Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.SchemaV2_2;
+
+namespace Persistence.Tests.PaYaml;
+
+[TestClass]
+public class PaYamlSerializerTests : TestBase
+{
+    #region Deserialize Examples
+
+    [TestMethod]
+    [DataRow(@"_TestData/SchemaV2_2/Examples/Src/App.pa.yaml", 5, 5)]
+    public void DeserializeExamplePaYamlApp(string path, int expectedAppPropertiesCount, int? expectedHostPropertiesCount)
+    {
+        var paFileRoot = PaYamlSerializer.Deserialize<PaFileRoot>(File.ReadAllText(path));
+        paFileRoot.ShouldNotBeNull();
+
+        // Top level properties
+        paFileRoot.App.ShouldNotBeNull();
+        paFileRoot.ComponentDefinitions.Should().BeNullOrEmpty();
+        paFileRoot.Screens.Should().BeNullOrEmpty();
+
+        paFileRoot.App.Properties.Should().NotBeNull()
+            .And.HaveCount(expectedAppPropertiesCount);
+        if (expectedHostPropertiesCount == null)
+        {
+            paFileRoot.App.Children?.Host.Should().BeNull();
+        }
+        else
+        {
+            paFileRoot.App.Children?.Host.Should().NotBeNull();
+            paFileRoot.App.Children?.Host?.Properties.Should().HaveCount(expectedHostPropertiesCount.Value);
+        }
+    }
+
+    [TestMethod]
+    [DataRow(@"_TestData/SchemaV2_2/Examples/Src/Screens/Screen1.pa.yaml", 2, 6, 16)]
+    [DataRow(@"_TestData/SchemaV2_2/Examples/Src/Screens/FormsScreen2.pa.yaml", 0, 1, 62)]
+    [DataRow(@"_TestData/SchemaV2_2/Examples/Src/Screens/ComponentsScreen4.pa.yaml", 0, 6, 6)]
+    public void DeserializeExamplePaYamlScreen(string path, int expectedScreenPropertiesCount, int expectedScreenChildrenCount, int expectedDescendantsCount)
+    {
+        var paFileRoot = PaYamlSerializer.Deserialize<PaFileRoot>(File.ReadAllText(path));
+        paFileRoot.ShouldNotBeNull();
+
+        // Top level properties
+        paFileRoot.App.Should().BeNull();
+        paFileRoot.ComponentDefinitions.Should().BeNullOrEmpty();
+        paFileRoot.Screens.ShouldNotBeNull();
+
+        // Check screen counts
+        paFileRoot.Screens.Should().HaveCount(1);
+        var screen = paFileRoot.Screens.First().Value;
+        if (expectedScreenPropertiesCount == 0)
+            screen.Properties.Should().BeNull();
+        else
+            screen.Properties.Should().NotBeNull()
+                .And.HaveCount(expectedScreenPropertiesCount);
+        screen.Children.Should().HaveCount(expectedScreenChildrenCount);
+        screen.GetDescendantsCount().Should().Be(expectedDescendantsCount);
+    }
+
+    [TestMethod]
+    [DataRow(@"_TestData/SchemaV2_2/Examples/Src/Components/MyHeaderComponent.pa.yaml", 9, 6, 1)]
+    public void DeserializeExamplePaYamlComponentDefinition(string path, int expectedCustomPropertiesCount, int expectedPropertiesCount, int expectedChildrenCount)
+    {
+        var paFileRoot = PaYamlSerializer.Deserialize<PaFileRoot>(File.ReadAllText(path));
+        paFileRoot.ShouldNotBeNull();
+
+        // Top level properties
+        paFileRoot.App.Should().BeNull();
+        paFileRoot.ComponentDefinitions.ShouldNotBeNull();
+        paFileRoot.Screens.Should().BeNullOrEmpty();
+
+        // Check components counts
+        paFileRoot.ComponentDefinitions.Should().HaveCount(1);
+        var componentDefinition = paFileRoot.ComponentDefinitions.First().Value;
+        componentDefinition.Properties.Should().HaveCount(expectedPropertiesCount);
+        componentDefinition.CustomProperties.Should().HaveCount(expectedCustomPropertiesCount);
+        componentDefinition.Children.Should().HaveCount(expectedChildrenCount);
+    }
+
+    [TestMethod]
+    public void DeserializeExamplePaYamlSingleFileApp()
+    {
+        var path = @"_TestData/SchemaV2_2/Examples/Single-File-App.pa.yaml";
+        var paFileRoot = PaYamlSerializer.Deserialize<PaFileRoot>(File.ReadAllText(path));
+        paFileRoot.ShouldNotBeNull();
+
+        // Top level properties
+        paFileRoot.App.ShouldNotBeNull();
+        paFileRoot.ComponentDefinitions.Should().BeNullOrEmpty();
+        paFileRoot.Screens.ShouldNotBeNull();
+
+        // Check random spot in the document
+        paFileRoot.App.Properties.Should().ContainKey("Theme");
+        var screen = paFileRoot.Screens.Should().ContainKey("Screen1").WhoseValue;
+        screen.Properties.Should().BeNullOrEmpty();
+        screen.Children.Should().HaveCount(2);
+    }
+
+    #endregion
+
+    #region RoundTrip from yaml
+
+    [TestMethod]
+    [DataRow(@"_TestData/SchemaV2_2/Examples/Src/App.pa.yaml")]
+    [DataRow(@"_TestData/SchemaV2_2/Examples/Src/Screens/Screen1.pa.yaml")]
+    [DataRow(@"_TestData/SchemaV2_2/Examples/Src/Screens/FormsScreen2.pa.yaml")]
+    [DataRow(@"_TestData/SchemaV2_2/Examples/Src/Screens/ComponentsScreen4.pa.yaml")]
+    [DataRow(@"_TestData/SchemaV2_2/Examples/Src/Components/MyHeaderComponent.pa.yaml")]
+    [DataRow(@"_TestData/SchemaV2_2/Examples/Single-File-App.pa.yaml")]
+    public void RoundTripFromYaml(string path)
+    {
+        var originalYaml = File.ReadAllText(path);
+        var paFileRoot = PaYamlSerializer.Deserialize<PaFileRoot>(originalYaml);
+        paFileRoot.ShouldNotBeNull();
+
+        var roundTrippedYaml = PaYamlSerializer.Serialize(paFileRoot);
+        TestContext.WriteTextWithLineNumbers(roundTrippedYaml, "roundTrippedYaml:");
+        roundTrippedYaml.Should().BeYamlEquivalentTo(originalYaml);
+    }
+
+    #endregion
+}

--- a/src/Persistence.Tests/PaYaml/Serialization/PFxExpressionYamlConverterTests.cs
+++ b/src/Persistence.Tests/PaYaml/Serialization/PFxExpressionYamlConverterTests.cs
@@ -1,0 +1,112 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.PowerFx;
+using Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Serialization;
+using YamlDotNet.Serialization;
+
+namespace Persistence.Tests.PaYaml.Serialization;
+
+[TestClass]
+public class PFxExpressionYamlConverterTests : TestBase
+{
+    private static readonly PFxExpressionYamlFormattingOptions FailSafeOptions = new()
+    {
+        ForceLiteralBlockIfContainsAny = null //new[] { "\"" }
+    };
+
+    [TestMethod]
+    public void ReadYamlWithFailSafeOptions()
+    {
+        var deserializer = new DeserializerBuilder()
+            .WithTypeConverter(new PFxExpressionYamlConverter(FailSafeOptions))
+            .Build();
+
+        void VerifyDeserialize(string yaml, string? expectedScript)
+        {
+            var testObject = deserializer.Deserialize<NamedPFxExpressionYaml>(yaml);
+            testObject.ShouldNotBeNull();
+            if (expectedScript is null)
+            {
+                testObject.Expression.Should().BeNull();
+            }
+            else
+            {
+                testObject.Expression.ShouldNotBeNull();
+                testObject.Expression.InvariantScript.Should().Be(expectedScript);
+            }
+        }
+
+        // Null literals
+        VerifyDeserialize("Expression: ", null);
+        VerifyDeserialize("Expression:", null);
+        VerifyDeserialize("Expression: ~", null);
+        VerifyDeserialize("Expression: Null", null);
+
+        // Plain scalars
+        VerifyDeserialize("Expression: =foo", "foo");
+        VerifyDeserialize("Expression: =null", "null");
+        VerifyDeserialize("Expression: =\"Hello world!\"", "\"Hello world!\"");
+
+        // Literal blocks
+        VerifyDeserialize("Expression: |\n  =foo", "foo");
+        VerifyDeserialize("Expression: |\n  =null", "null");
+        VerifyDeserialize("Expression: |\n  =\"Hello world!\"", @"""Hello world!""");
+
+        // Multiline scripts
+        VerifyDeserialize("Expression: |-\n  =val1\n   & \n  foo", "val1\n & \nfoo");
+        VerifyDeserialize("Expression: |\n  =val1\n   & \n  foo", "val1\n & \nfoo");
+        VerifyDeserialize("Expression: |-\n  =val1\n   & \n  foo\n", "val1\n & \nfoo");
+        VerifyDeserialize("Expression: |\n  =val1\n   & \n  foo\n", "val1\n & \nfoo\n");
+        VerifyDeserialize("Expression: |-\n  =val1\n   & \n  foo\n  ", "val1\n & \nfoo");
+        VerifyDeserialize("Expression: |\n  =val1\n   & \n  foo\n  ", "val1\n & \nfoo\n");
+    }
+
+    [TestMethod]
+    public void WriteYamlWithFailSafeOptions()
+    {
+        var serializer = new SerializerBuilder()
+            .WithNewLine("\n") // Ensure tests are consistent across platforms
+            .WithTypeConverter(new PFxExpressionYamlConverter(FailSafeOptions))
+            .Build();
+
+        void VerifySerialize(string? pfxScript, string expectedExpressionYaml)
+        {
+            var expression = pfxScript is null ? null : new PFxExpressionYaml(pfxScript);
+            var testObject = new NamedPFxExpressionYaml(expression);
+            var expectedYaml = expectedExpressionYaml is null ? "Expression:" : $"Expression: {expectedExpressionYaml}\n";
+            var actualYaml = serializer.Serialize(testObject);
+            actualYaml.Should().Be(expectedYaml);
+        }
+
+        // Only the canonical null literal will be written:
+        VerifySerialize(null, "");
+
+        // Plain scalars
+        VerifySerialize("foo", "=foo");
+        VerifySerialize("null", "=null");
+        VerifySerialize(@"""Hello world!""", "=\"Hello world!\"");
+
+        // Forced to literal blocks
+        VerifySerialize("Format(val, # has pound)", "|-\n  =Format(val, # has pound)");
+        VerifySerialize("Format(val, : has colon)", "|-\n  =Format(val, : has colon)");
+
+        // Multiline scripts
+        VerifySerialize("val1\n & \nfoo", "|-\n  =val1\n   & \n  foo");
+        VerifySerialize("val1\n & \nfoo\n", "|\n  =val1\n   & \n  foo");
+    }
+
+    public record NamedPFxExpressionYaml
+    {
+        public NamedPFxExpressionYaml()
+        {
+        }
+
+        public NamedPFxExpressionYaml(PFxExpressionYaml? expression)
+        {
+            Expression = expression;
+        }
+
+        public PFxExpressionYaml? Expression { get; init; }
+    }
+}

--- a/src/Persistence.Tests/Persistence.Tests.csproj
+++ b/src/Persistence.Tests/Persistence.Tests.csproj
@@ -18,6 +18,9 @@
         <None Include="_TestData\**\*">
             <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
         </None>
+      <None Include="..\schemas-tests\pa-yaml\v2.2\Examples\**\*.yaml" LinkBase="_TestData\SchemaV2_2\Examples\">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Persistence.Tests/TestBase.cs
+++ b/src/Persistence.Tests/TestBase.cs
@@ -32,7 +32,7 @@ public class TestBase
         ControlFactory = ServiceProvider.GetRequiredService<IControlFactory>();
     }
 
-    public static IServiceProvider BuildServiceProvider()
+    private static IServiceProvider BuildServiceProvider()
     {
         var serviceCollection = new ServiceCollection();
         var serviceProvider = ConfigureServices(serviceCollection);

--- a/src/Persistence/GlobalSuppressions.cs
+++ b/src/Persistence/GlobalSuppressions.cs
@@ -1,0 +1,8 @@
+// This file is used by Code Analysis to maintain SuppressMessage
+// attributes that are applied to this project.
+// Project-level suppressions either have no target or are given
+// a specific target and scoped to a namespace, type, member, etc.
+
+using System.Diagnostics.CodeAnalysis;
+
+[assembly: SuppressMessage("Naming", "CA1707:Identifiers should not contain underscores", Justification = "Version number in namespace.", Scope = "namespace", Target = "~N:Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.SchemaV2_2")]

--- a/src/Persistence/PaYaml/Models/PowerFx/PFxDataType.cs
+++ b/src/Persistence/PaYaml/Models/PowerFx/PFxDataType.cs
@@ -1,0 +1,19 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.PowerFx;
+
+public enum PFxDataType
+{
+    Text,
+    Number,
+    Boolean,
+    DateAndTime,
+    Screen,
+    Record,
+    Table,
+    Image,
+    VideoOrAudio,
+    Color,
+    Currency,
+}

--- a/src/Persistence/PaYaml/Models/PowerFx/PFxExpressionYaml.cs
+++ b/src/Persistence/PaYaml/Models/PowerFx/PFxExpressionYaml.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using YamlDotNet.Serialization;
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.PowerFx;
+
+// REVIEW: Consider implementing IYamlConvertible instead of using a custom converter.
+public record PFxExpressionYaml(
+    [property: YamlIgnore]
+    string InvariantScript)
+{
+}

--- a/src/Persistence/PaYaml/Models/PowerFx/PFxFunctionParameter.cs
+++ b/src/Persistence/PaYaml/Models/PowerFx/PFxFunctionParameter.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.PowerFx;
+
+public record PFxFunctionParameter()
+{
+    public string? Description { get; init; }
+
+    public bool IsRequired { get; init; }
+
+    public PFxDataType? DataType { get; init; }
+
+    public PFxExpressionYaml? Default { get; init; }
+}

--- a/src/Persistence/PaYaml/Models/SchemaV2_2/AppInstance.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV2_2/AppInstance.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.PowerFx;
+using YamlDotNet.Serialization;
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.SchemaV2_2;
+
+public record AppInstance
+{
+    public SortedDictionary<string, PFxExpressionYaml>? Properties { get; init; }
+
+    public AppInstanceChildren? Children { get; init; }
+}
+
+public record AppInstanceChildren
+{
+    public HostControlInstance? Host { get; init; }
+
+    [YamlIgnore]
+    public int Count => Host != null ? 1 : 0;
+}
+
+public record HostControlInstance
+{
+    public SortedDictionary<string, PFxExpressionYaml>? Properties { get; init; }
+}

--- a/src/Persistence/PaYaml/Models/SchemaV2_2/ComponentDefinition.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV2_2/ComponentDefinition.cs
@@ -1,0 +1,56 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.PowerFx;
+using YamlDotNet.Serialization;
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.SchemaV2_2;
+
+public enum ComponentPropertyKind
+{
+    Input,
+    Output,
+    InputFunction,
+    OutputFunction,
+    Event,
+    Action,
+}
+
+public class ComponentDefinition
+{
+    public string? Description { get; init; }
+
+    public bool AccessAppScope { get; init; }
+
+    public Dictionary<string, ComponentCustomPropertyUnion>? CustomProperties { get; init; }
+
+    public SortedDictionary<string, PFxExpressionYaml>? Properties { get; init; }
+
+    public List<Dictionary<string, ControlInstance>>? Children { get; init; }
+}
+
+public abstract class ComponentCustomPropertyBase
+{
+    [YamlMember(DefaultValuesHandling = DefaultValuesHandling.Preserve)]
+    public required ComponentPropertyKind PropertyKind { get; init; }
+
+    public string? DisplayName { get; init; }
+
+    public string? Description { get; init; }
+}
+
+/// <summary>
+/// Represents the union of all possible properties available on any custom property.
+/// </summary>
+public class ComponentCustomPropertyUnion : ComponentCustomPropertyBase
+{
+    public PFxDataType? DataType { get; init; }
+
+    public bool? RaiseOnReset { get; init; }
+
+    public PFxExpressionYaml? Default { get; init; }
+
+    public string? ReturnType { get; init; }
+
+    public List<Dictionary<string, PFxFunctionParameter>>? Parameters { get; init; }
+}

--- a/src/Persistence/PaYaml/Models/SchemaV2_2/ControlInstance.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV2_2/ControlInstance.cs
@@ -1,0 +1,23 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.PowerFx;
+using YamlDotNet.Serialization;
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.SchemaV2_2;
+
+public record ControlInstance
+{
+    [property: YamlMember(Alias = "Control")]
+    public required string ControlType { get; init; }
+
+    public string? Variant { get; init; }
+
+    public string? ComponentName { get; init; }
+
+    public string? ComponentLibraryUniqueName { get; init; }
+
+    public SortedDictionary<string, PFxExpressionYaml>? Properties { get; init; }
+
+    public List<Dictionary<string, ControlInstance>>? Children { get; init; }
+}

--- a/src/Persistence/PaYaml/Models/SchemaV2_2/ModelsExtensions.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV2_2/ModelsExtensions.cs
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.SchemaV2_2;
+
+public static class ModelsExtensions
+{
+    public static int GetDescendantsCount(this ScreenInstance screen)
+    {
+        _ = screen ?? throw new ArgumentNullException(nameof(screen));
+
+        var count = 0;
+        if (screen.Children?.Count > 0)
+        {
+            count += screen.Children.Count;
+
+            foreach (var namedDict in screen.Children)
+            {
+                Debug.Assert(namedDict.Count == 1, "Each child of a screen should represent a dictionary with a single item.");
+                var namedControl = namedDict.Single();
+
+                count += namedControl.Value.GetDescendantsCount();
+            }
+        }
+
+        return count;
+    }
+
+    public static int GetDescendantsCount(this ControlInstance control)
+    {
+        _ = control ?? throw new ArgumentNullException(nameof(control));
+
+        var count = 0;
+        if (control.Children?.Count > 0)
+        {
+            count += control.Children.Count;
+
+            foreach (var namedDict in control.Children)
+            {
+                Debug.Assert(namedDict.Count == 1, "Each child of a screen should represent a dictionary with a single item.");
+                var namedControl = namedDict.Single();
+
+                count += namedControl.Value.GetDescendantsCount();
+            }
+        }
+
+        return count;
+    }
+}

--- a/src/Persistence/PaYaml/Models/SchemaV2_2/PaFileRoot.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV2_2/PaFileRoot.cs
@@ -1,0 +1,11 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.SchemaV2_2;
+
+public record PaFileRoot
+{
+    public AppInstance? App { get; init; }
+    public Dictionary<string, ScreenInstance>? Screens { get; init; }
+    public Dictionary<string, ComponentDefinition>? ComponentDefinitions { get; init; }
+}

--- a/src/Persistence/PaYaml/Models/SchemaV2_2/SchemaKeywords.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV2_2/SchemaKeywords.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.SchemaV2_2;
+
+public static class SchemaKeywords
+{
+    // Top-level property names:
+    public const string App = nameof(App);
+    public const string Screens = nameof(Screens);
+
+    // Common property names:
+    public const string Properties = nameof(Properties);
+    public const string Children = nameof(Children);
+
+    // Other names:
+    public const string Host = nameof(Host);
+}

--- a/src/Persistence/PaYaml/Models/SchemaV2_2/ScreenInstance.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV2_2/ScreenInstance.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.PowerFx;
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.SchemaV2_2;
+
+public record ScreenInstance
+{
+    public SortedDictionary<string, PFxExpressionYaml>? Properties { get; init; }
+
+    public List<Dictionary<string, ControlInstance>>? Children { get; init; }
+}

--- a/src/Persistence/PaYaml/PaYamlDotNetExtensions.cs
+++ b/src/Persistence/PaYaml/PaYamlDotNetExtensions.cs
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization.NodeDeserializers;
+using YamlDotNet.Serialization.Schemas;
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml;
+
+internal static class PaYamlDotNetExtensions
+{
+    private static readonly NullNodeDeserializer _nullNodeDeserializer = new();
+    private static readonly Type _typeofObject = typeof(object);
+    private static readonly Scalar _nullImplicitPlainScalar = new(null, JsonSchema.Tags.Null, string.Empty, ScalarStyle.Plain, isPlainImplicit: true, isQuotedImplicit: false);
+
+    /// <summary>
+    /// If the current event represents a YAML null value, consumes it and returns true; otherwise, returns false.
+    /// </summary>
+    /// <returns>true if the current event represented a YAML null value and the event was consumed.</returns>
+    public static bool TryConsumeNull(this IParser parser)
+    {
+        // NullNodeDeserializer.Deserialize is undocumented, but here's a good summary of what it does:
+        // Attempts to consume the current node event iif it represents a YAML null value. Otherwise, the current event stays.
+        // Returns true if the current node was a null value and was consumed; otherwise, false.
+        return _nullNodeDeserializer.Deserialize(parser, _typeofObject, null!, out _);
+    }
+
+    public static void EmitNull(this IEmitter emitter)
+    {
+        emitter.Emit(_nullImplicitPlainScalar);
+    }
+}

--- a/src/Persistence/PaYaml/PaYamlSerializationException.cs
+++ b/src/Persistence/PaYaml/PaYamlSerializationException.cs
@@ -1,0 +1,27 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Runtime.Serialization;
+using YamlDotNet.Core;
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml;
+
+[Serializable]
+internal class PaYamlSerializationException : Exception
+{
+    public PaYamlSerializationException(string message, Mark eventStart) : base(message)
+    {
+        EventStart = eventStart;
+    }
+
+    public PaYamlSerializationException(string message, Mark eventStart, Exception? innerException) : base(message, innerException)
+    {
+        EventStart = eventStart;
+    }
+
+    protected PaYamlSerializationException(SerializationInfo info, StreamingContext context) : base(info, context)
+    {
+    }
+
+    public Mark EventStart { get; }
+}

--- a/src/Persistence/PaYaml/PaYamlSerializer.cs
+++ b/src/Persistence/PaYaml/PaYamlSerializer.cs
@@ -1,0 +1,105 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Globalization;
+using System.Text;
+using YamlDotNet.Serialization;
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml;
+
+public static class PaYamlSerializer
+{
+    private static readonly Encoding Utf8NoBom = new UTF8Encoding(encoderShouldEmitUTF8Identifier: false);
+
+    #region Serialize
+
+    /// <summary>
+    /// Converts the value of a type specified by a generic type parameter into a YAML string.
+    /// </summary>
+    /// <typeparam name="TValue">The type of the value to serialize.</typeparam>
+    /// <param name="value">The value to convert.</param>
+    /// <param name="options">Options to control serialization behavior.</param>
+    /// <returns></returns>
+    public static string Serialize<TValue>(TValue value, PaYamlSerializerOptions? options = null)
+    {
+        var sb = new StringBuilder();
+        using (var writer = new StringWriter(sb, CultureInfo.InvariantCulture))
+        {
+            WriteTextWriter(writer, value, options);
+        }
+        return sb.ToString();
+    }
+
+    public static void Serialize<TValue>(Stream utf8Stream, TValue value, PaYamlSerializerOptions? options = null)
+    {
+        _ = utf8Stream ?? throw new ArgumentNullException(nameof(utf8Stream));
+
+        using (var writer = new StreamWriter(utf8Stream, Utf8NoBom))
+        {
+            WriteTextWriter(writer, value, options);
+        }
+    }
+
+    private static void WriteTextWriter<TValue>(TextWriter writer, in TValue? value, PaYamlSerializerOptions? options)
+    {
+        _ = writer ?? throw new ArgumentNullException(nameof(writer));
+
+        options ??= PaYamlSerializerOptions.Default;
+        var targetType = typeof(TValue);
+
+        // Configure the YamlDotNet serializer
+        var builder = new SerializerBuilder();
+        options.ApplyToSerializerBuilder(builder);
+        var serializer = builder.Build();
+
+        serializer.Serialize(writer, value, targetType);
+    }
+    #endregion
+
+    #region Deserialize
+
+    /// <summary>
+    /// Parses the text representing a single YAML value into an instance of the type specified by a generic type parameter.
+    /// </summary>
+    /// <typeparam name="TValue">The target type of the YAML value.</typeparam>
+    /// <param name="yaml">The YAML text to parse.</param>
+    /// <param name="options">Options to control the behavior during parsing.</param>
+    /// <returns></returns>
+    public static TValue? Deserialize<TValue>(string yaml, PaYamlSerializerOptions? options = null)
+        where TValue : notnull
+    {
+        _ = yaml ?? throw new ArgumentNullException(nameof(yaml));
+
+        using (var reader = new StringReader(yaml))
+        {
+            return ReadFromReader<TValue>(reader, options);
+        }
+    }
+
+    public static TValue? Deserialize<TValue>(Stream utf8Stream, PaYamlSerializerOptions? options = null)
+        where TValue : notnull
+    {
+        _ = utf8Stream ?? throw new ArgumentNullException(nameof(utf8Stream));
+
+        using (var reader = new StreamReader(utf8Stream, detectEncodingFromByteOrderMarks: true))
+        {
+            return ReadFromReader<TValue>(reader, options);
+        }
+    }
+
+    private static TValue? ReadFromReader<TValue>(TextReader reader, PaYamlSerializerOptions? options)
+        where TValue : notnull
+    {
+        _ = reader ?? throw new ArgumentNullException(nameof(reader));
+
+        options ??= PaYamlSerializerOptions.Default;
+
+        // Configure the YamlDotNet serializer
+        var builder = new DeserializerBuilder();
+        options.ApplyToDeserializerBuilder(builder);
+        var serializer = builder.Build();
+
+        return serializer.Deserialize<TValue>(reader);
+    }
+    #endregion
+}

--- a/src/Persistence/PaYaml/PaYamlSerializerOptions.cs
+++ b/src/Persistence/PaYaml/PaYamlSerializerOptions.cs
@@ -12,7 +12,7 @@ public record PaYamlSerializerOptions
     internal static readonly PaYamlSerializerOptions Default = new();
 
     public string NewLine { get; init; } = "\n";
-    public bool IsTextFirst { get; init; }
+
     public PFxExpressionYamlFormattingOptions PFxExpressionYamlFormatting { get; init; } = new();
 
     public Action<DeserializerBuilder>? AdditionalDeserializerConfiguration { get; init; }
@@ -30,13 +30,12 @@ public record PaYamlSerializerOptions
 
     internal void ApplyToSerializerBuilder(SerializerBuilder builder)
     {
+        // TODO: Can we control indentation chars? e.g. to be explicitly set to 2 spaces?
         builder
             .WithQuotingNecessaryStrings()
             .WithNewLine(NewLine)
             .DisableAliases()
-            //.WithDefaultScalarStyle(ScalarStyle.Any) // default is Any
             .WithEnumNamingConvention(PascalCaseNamingConvention.Instance)
-            // TODO: Can we control indentation chars? e.g. to be explicitly set to 2 spaces?
             .WithIndentedSequences() // to match VS Code's default formatting settings
             .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitEmptyCollections | DefaultValuesHandling.OmitNull | DefaultValuesHandling.OmitDefaults)
             ;
@@ -48,12 +47,5 @@ public record PaYamlSerializerOptions
         where TBuilder : BuilderSkeleton<TBuilder>
     {
         builder.WithTypeConverter(new PFxExpressionYamlConverter(PFxExpressionYamlFormatting));
-
-        //.WithObjectFactory(new ControlObjectFactory(_controlTemplateStore, _controlFactory))
-        //.WithTypeInspector(inner => new ControlTypeInspector(inner, _controlTemplateStore))
-        //.WithTypeDiscriminatingNodeDeserializer(o =>
-        //{
-        //    o.AddTypeDiscriminator(new ControlTypeDiscriminator(_controlTemplateStore));
-        //})
     }
 }

--- a/src/Persistence/PaYaml/PaYamlSerializerOptions.cs
+++ b/src/Persistence/PaYaml/PaYamlSerializerOptions.cs
@@ -1,0 +1,59 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Serialization;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml;
+
+public record PaYamlSerializerOptions
+{
+    internal static readonly PaYamlSerializerOptions Default = new();
+
+    public string NewLine { get; init; } = "\n";
+    public bool IsTextFirst { get; init; }
+    public PFxExpressionYamlFormattingOptions PFxExpressionYamlFormatting { get; init; } = new();
+
+    public Action<DeserializerBuilder>? AdditionalDeserializerConfiguration { get; init; }
+
+    public Action<SerializerBuilder>? AdditionalSerializerConfiguration { get; init; }
+
+    internal void ApplyToDeserializerBuilder(DeserializerBuilder builder)
+    {
+        builder
+            .WithDuplicateKeyChecking()
+            ;
+        AddTypeConverters(builder);
+        AdditionalDeserializerConfiguration?.Invoke(builder);
+    }
+
+    internal void ApplyToSerializerBuilder(SerializerBuilder builder)
+    {
+        builder
+            .WithQuotingNecessaryStrings()
+            .WithNewLine(NewLine)
+            .DisableAliases()
+            //.WithDefaultScalarStyle(ScalarStyle.Any) // default is Any
+            .WithEnumNamingConvention(PascalCaseNamingConvention.Instance)
+            // TODO: Can we control indentation chars? e.g. to be explicitly set to 2 spaces?
+            .WithIndentedSequences() // to match VS Code's default formatting settings
+            .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitEmptyCollections | DefaultValuesHandling.OmitNull | DefaultValuesHandling.OmitDefaults)
+            ;
+        AddTypeConverters(builder);
+        AdditionalSerializerConfiguration?.Invoke(builder);
+    }
+
+    private void AddTypeConverters<TBuilder>(BuilderSkeleton<TBuilder> builder)
+        where TBuilder : BuilderSkeleton<TBuilder>
+    {
+        builder.WithTypeConverter(new PFxExpressionYamlConverter(PFxExpressionYamlFormatting));
+
+        //.WithObjectFactory(new ControlObjectFactory(_controlTemplateStore, _controlFactory))
+        //.WithTypeInspector(inner => new ControlTypeInspector(inner, _controlTemplateStore))
+        //.WithTypeDiscriminatingNodeDeserializer(o =>
+        //{
+        //    o.AddTypeDiscriminator(new ControlTypeDiscriminator(_controlTemplateStore));
+        //})
+    }
+}

--- a/src/Persistence/PaYaml/Serialization/PFxExpressionYamlConverter.cs
+++ b/src/Persistence/PaYaml/Serialization/PFxExpressionYamlConverter.cs
@@ -51,12 +51,12 @@ public class PFxExpressionYamlConverter : IYamlTypeConverter
 
         // If the script contains a substring that would cause extra yaml escaping, force it to a literal block
         // The goal here for PFx yaml is that we avoid using yaml string escaping whenever possible.
-        var forceLiteralBlock =
-            // These char sequences are special to YAML parsers, so must be escaped or forced to literal block
-            expression.InvariantScript.Contains(" #")
-            || expression.InvariantScript.Contains(": ")
-            // Force multi-line scripts to be literal blocks
-            || expression.InvariantScript.Contains('\n')
+
+        // These char sequences are special to YAML parsers, so must be escaped or forced to literal block
+        var forceLiteralBlock = expression.InvariantScript.Contains(" #")
+            || expression.InvariantScript.Contains(": ");
+        // Force multi-line scripts to be literal blocks
+        forceLiteralBlock |= expression.InvariantScript.Contains('\n')
             || expression.InvariantScript.Contains('\r');
         if (!forceLiteralBlock && _formattingOptions.ForceLiteralBlockIfContainsAny?.Count > 0)
         {

--- a/src/Persistence/PaYaml/Serialization/PFxExpressionYamlConverter.cs
+++ b/src/Persistence/PaYaml/Serialization/PFxExpressionYamlConverter.cs
@@ -1,0 +1,73 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using YamlDotNet.Core;
+using YamlDotNet.Serialization;
+using YamlDotNet.Core.Events;
+using Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.PowerFx;
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Serialization;
+
+// BUG 27469059: Internal classes not accessible to test project. InternalsVisibleTo attribute added to csproj doesn't get emitted because GenerateAssemblyInfo is false.
+public class PFxExpressionYamlConverter : IYamlTypeConverter
+{
+    private readonly PFxExpressionYamlFormattingOptions _formattingOptions;
+
+    public PFxExpressionYamlConverter(PFxExpressionYamlFormattingOptions formattingOptions)
+    {
+        _formattingOptions = formattingOptions ?? throw new ArgumentNullException(nameof(formattingOptions));
+    }
+
+    public bool Accepts(Type type)
+    {
+        return type == typeof(PFxExpressionYaml);
+    }
+
+    public object? ReadYaml(IParser parser, Type type)
+    {
+        if (parser.TryConsumeNull())
+            return null;
+
+        var scalar = parser.Consume<Scalar>();
+
+        // Detect canonical format, where expressions should always start with '=' character
+        if (scalar.Value.Length >= 1 && scalar.Value[0] == PFxExpressionYamlFormattingOptions.ScalarPrefix)
+        {
+            var script = scalar.Value[1..];
+            return new PFxExpressionYaml(script);
+        }
+
+        throw new PaYamlSerializationException($"Power Fx expressions must start with '{PFxExpressionYamlFormattingOptions.ScalarPrefix}'.", scalar.Start);
+    }
+
+    public void WriteYaml(IEmitter emitter, object? value, Type type)
+    {
+        var expression = (PFxExpressionYaml?)value;
+        if (expression is null)
+        {
+            emitter.EmitNull();
+            return;
+        }
+
+        // If the script contains a substring that would cause extra yaml escaping, force it to a literal block
+        // The goal here for PFx yaml is that we avoid using yaml string escaping whenever possible.
+        var forceLiteralBlock =
+            // These char sequences are special to YAML parsers, so must be escaped or forced to literal block
+            expression.InvariantScript.Contains(" #")
+            || expression.InvariantScript.Contains(": ")
+            // Force multi-line scripts to be literal blocks
+            || expression.InvariantScript.Contains('\n')
+            || expression.InvariantScript.Contains('\r');
+        if (!forceLiteralBlock && _formattingOptions.ForceLiteralBlockIfContainsAny?.Count > 0)
+        {
+            // e.g. our original code was forcing literal block if the script contained any double quotes (`"`).
+            forceLiteralBlock |= _formattingOptions.ForceLiteralBlockIfContainsAny.Any(expression.InvariantScript.Contains);
+        }
+
+        // Construct the scalar value to emit, which must have the '=' prefix
+        var yamlScalarValue = $"{PFxExpressionYamlFormattingOptions.ScalarPrefix}{expression.InvariantScript}";
+
+        emitter.Emit(new Scalar(AnchorName.Empty, TagName.Empty, yamlScalarValue, forceLiteralBlock ? ScalarStyle.Literal : ScalarStyle.Any,
+            isPlainImplicit: true, isQuotedImplicit: !forceLiteralBlock));
+    }
+}

--- a/src/Persistence/PaYaml/Serialization/PFxExpressionYamlFormattingOptions.cs
+++ b/src/Persistence/PaYaml/Serialization/PFxExpressionYamlFormattingOptions.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Serialization;
+
+public record PFxExpressionYamlFormattingOptions
+{
+    public const char ScalarPrefix = '=';
+
+    // Note: By default, we no longer force literal block when it contains a double quote, as these are not a problem when the '=' prefix is used.
+    public IReadOnlyList<string>? ForceLiteralBlockIfContainsAny { get; init; } //= new[] { "\"" };
+}

--- a/src/Persistence/Yaml/YamlSerializationFactory.cs
+++ b/src/Persistence/Yaml/YamlSerializationFactory.cs
@@ -27,11 +27,11 @@ public class YamlSerializationFactory : IYamlSerializationFactory
         options ??= YamlSerializerOptions.Default;
 
         var yamlSerializer = new SerializerBuilder()
-                .WithEventEmitter(next => new FirstClassControlsEmitter(next, _controlTemplateStore))
-                .WithTypeInspector(inner => new ControlTypeInspector(inner, _controlTemplateStore))
-                .WithTypeConverter(new ControlPropertiesCollectionConverter() { IsTextFirst = options.IsTextFirst })
-                .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitEmptyCollections | DefaultValuesHandling.OmitNull)
-           .Build();
+            .WithEventEmitter(next => new FirstClassControlsEmitter(next, _controlTemplateStore))
+            .WithTypeInspector(inner => new ControlTypeInspector(inner, _controlTemplateStore))
+            .WithTypeConverter(new ControlPropertiesCollectionConverter() { IsTextFirst = options.IsTextFirst })
+            .ConfigureDefaultValuesHandling(DefaultValuesHandling.OmitEmptyCollections | DefaultValuesHandling.OmitNull)
+            .Build();
 
         return new YamlSerializer(yamlSerializer);
     }


### PR DESCRIPTION
## Problem

Simple implementation of Yaml Schema v2.2 OM (as defined in XR and schema file already in master).

## Solution

Added a new OM and namespace for representing just the Yaml schema for *.pa.yaml files.
Added unit tests and also verify the Example pa.yaml files written according to the schema.

NOTE: This OM is an initial implementation to enable the start of writing the transformation from the existing OM (aka v2.1) to v2.2.