### PR TITLE
Reverse ZIndex ordering for children of group containers

### DIFF
--- a/src/Persistence/Models/Control.cs
+++ b/src/Persistence/Models/Control.cs
@@ -105,7 +105,7 @@ public abstract record Control
         var zindexCalc = (int i) => Children.Count - i;
         // For group containers, ZIndex is the actual order of what is shown in the tree view, not descending.
         // Handle that here to ensure we match what is expected
-        if (Template.Name == "GroupContainer")
+        if (Template.Name == BuiltInTemplates.GroupContainer)
         {
             zindexCalc = (int i) => i + 1;
         }
@@ -126,7 +126,7 @@ public abstract record Control
 
         // For group containers, ZIndex is the reverse order of what is shown in the tree view
         // Handle that here to ensure we match what is expected
-        if (Template.Name == "GroupContainer")
+        if (Template.Name == BuiltInTemplates.GroupContainer)
         {
             zIndexComparison = (Control c1, Control c2) => c1.ZIndex.CompareTo(c2.ZIndex);
         }

--- a/src/Persistence/Templates/BuiltInTemplates.cs
+++ b/src/Persistence/Templates/BuiltInTemplates.cs
@@ -10,5 +10,8 @@ public static class BuiltInTemplates
     public const string Screen = "Screen";
     public const string Component = "Component";
     public const string CommandComponent = "CommandComponent";
+    // Group is the legacy group container template
     public const string Group = "Group";
+    // Group Container is the newer layout container template
+    public const string GroupContainer = "GroupContainer";
 }


### PR DESCRIPTION
Children of group containers are ordered in the tree view in reverse of zindex order. This update changes the serialize/deserialize logic so that the serialized order matches the tree view order. 