### PR TITLE
removed unnecessary category field

### DIFF
--- a/src/Persistence.Tests/Model/CustomPropertyTests.cs
+++ b/src/Persistence.Tests/Model/CustomPropertyTests.cs
@@ -1,0 +1,27 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.PowerPlatform.PowerApps.Persistence.Models;
+
+namespace Persistence.Tests.Model;
+
+[TestClass]
+public class CustomPropertyTests
+{
+    [TestMethod]
+    [DataRow(CustomProperty.PropertyType.Data, PropertyCategory.Data)]
+    [DataRow(CustomProperty.PropertyType.Event, PropertyCategory.Behavior)]
+    [DataRow(CustomProperty.PropertyType.Function, PropertyCategory.Data)]
+    [DataRow(CustomProperty.PropertyType.Action, PropertyCategory.Behavior)]
+    public void Category_shouldBeValidBasedOnType(CustomProperty.PropertyType propertyType, PropertyCategory expectedCategory)
+    {
+        var sut = new CustomProperty
+        {
+            Name = "Test",
+            Type = propertyType
+        };
+
+        // Assert
+        sut.Category.Should().Be(expectedCategory);
+    }
+}

--- a/src/Persistence.Tests/_TestData/ValidYaml-CI/Components/CustomProperty1.pa.yaml
+++ b/src/Persistence.Tests/_TestData/ValidYaml-CI/Components/CustomProperty1.pa.yaml
@@ -5,6 +5,5 @@ Component1:
       Direction: Input
       PropertyType: Data
       DataType: String
-      Category: Data
       IsResettable: false
       Default: lorem

--- a/src/Persistence.Tests/_TestData/ValidYaml-CI/Components/CustomProperty2.pa.yaml
+++ b/src/Persistence.Tests/_TestData/ValidYaml-CI/Components/CustomProperty2.pa.yaml
@@ -5,7 +5,6 @@ Component1:
       Direction: Input
       PropertyType: Function
       DataType: String
-      Category: Data
       IsResettable: false
       Default: lorem
       Parameters:

--- a/src/Persistence.Tests/_TestData/ValidYaml/Components/CustomProperty1.pa.yaml
+++ b/src/Persistence.Tests/_TestData/ValidYaml/Components/CustomProperty1.pa.yaml
@@ -5,6 +5,5 @@ CustomProperties:
     Direction: Input
     PropertyType: Data
     DataType: String
-    Category: Data
     IsResettable: false
     Default: lorem

--- a/src/Persistence.Tests/_TestData/ValidYaml/Components/CustomProperty2.pa.yaml
+++ b/src/Persistence.Tests/_TestData/ValidYaml/Components/CustomProperty2.pa.yaml
@@ -5,7 +5,6 @@ CustomProperties:
     Direction: Input
     PropertyType: Function
     DataType: String
-    Category: Data
     IsResettable: false
     Default: lorem
     Parameters:

--- a/src/Persistence/Models/CustomProperty.cs
+++ b/src/Persistence/Models/CustomProperty.cs
@@ -24,7 +24,9 @@ public record CustomProperty
     {
         PropertyType.Action => PropertyCategory.Behavior,
         PropertyType.Event => PropertyCategory.Behavior,
-        _ => PropertyCategory.Data
+        PropertyType.Data => PropertyCategory.Data,
+        PropertyType.Function => PropertyCategory.Data,
+        _ => throw new InvalidOperationException($"Invalid property type: {Type}")
     };
 
     public bool IsResettable { get; init; }

--- a/src/Persistence/Models/CustomProperty.cs
+++ b/src/Persistence/Models/CustomProperty.cs
@@ -19,8 +19,6 @@ public record CustomProperty
 
     public string DataType { get; init; } = "String";
 
-    public PropertyCategory Category { get; init; } = PropertyCategory.Data;
-
     public bool IsResettable { get; init; }
 
     public string? DisplayName { get; init; }

--- a/src/Persistence/Models/CustomProperty.cs
+++ b/src/Persistence/Models/CustomProperty.cs
@@ -19,6 +19,14 @@ public record CustomProperty
 
     public string DataType { get; init; } = "String";
 
+    [YamlIgnore]
+    public PropertyCategory Category => Type switch
+    {
+        PropertyType.Action => PropertyCategory.Behavior,
+        PropertyType.Event => PropertyCategory.Behavior,
+        _ => PropertyCategory.Data
+    };
+
     public bool IsResettable { get; init; }
 
     public string? DisplayName { get; init; }


### PR DESCRIPTION
The category field on Custom Properties can be inferred from the property type:
1. Data -> Data
2. Action ->Behavior
3. Event -> Behavior
4. Function -> Data