### PR TITLE
Update `ControlTemplate` to indicate whether it's a Component or Pcf control template

### DIFF
--- a/src/Persistence/Templates/ControlTemplate.cs
+++ b/src/Persistence/Templates/ControlTemplate.cs
@@ -62,4 +62,29 @@ public record ControlTemplate
     public ControlPropertiesCollection InputProperties { get; init; } = new();
 
     public IList<ControlTemplate>? NestedTemplates { get; init; }
+
+    public CustomComponentInfo? ComponentInfo { get; init; }
+
+    [MemberNotNullWhen(true, nameof(ComponentInfo))]
+    public bool IsCustomComponent => ComponentInfo != null;
+
+    public bool IsPcfControlTemplate { get; init; }
+
+    public class CustomComponentInfo
+    {
+        /// <summary>
+        /// The unique id (a form of guid) of the component as serialized in the app.
+        /// </summary>
+        public required string UniqueId { get; init; }
+
+        /// <summary>
+        /// The friendly identifier of the component.
+        /// </summary>
+        public required string Name { get; init; }
+
+        /// <summary>
+        /// The unique name of the component library if this component originates from a component library.
+        /// </summary>
+        public string? ComponentLibraryUniqueName { get; init; }
+    }
 }


### PR DESCRIPTION
## Problem

The current OM doesn't allow for control template to indicate whether it represents a custom component or a Pcf control.
Yaml serialization needs to be able to emit the identifiers used to uniquely identify a control instance.

## Solution

Added some new properties to `ControlTemplate`.

## Changes

- Added properties to `ControlTemplate`: `IsCustomComponent`, `ComponentInfo`, `IsPcfControlTemplate`

## Validation

Not used atm, but is a placeholder for getting the data from the Document Server.
