### PR TITLE
Remove [OnDeserialized] and [OnSerializing] hooks

### DIFF
--- a/src/Persistence/Models/Component.cs
+++ b/src/Persistence/Models/Component.cs
@@ -42,20 +42,6 @@ public record Component : Control, IConvertible
     [YamlMember(Order = 100)]
     public CustomPropertiesCollection CustomProperties { get; set; } = new();
 
-    [OnDeserialized]
-    internal override void AfterDeserialize()
-    {
-        base.AfterDeserialize();
-
-        if (CustomProperties != null)
-        {
-            foreach (var kv in CustomProperties)
-            {
-                kv.Value.Name = kv.Key;
-            }
-        }
-    }
-
     internal override void AfterCreate(Dictionary<string, object?> controlDefinition)
     {
         if (controlDefinition.TryGetValue<CustomPropertiesCollection>(nameof(CustomProperties), out var customProperties))

--- a/src/Persistence/Models/Component.cs
+++ b/src/Persistence/Models/Component.cs
@@ -7,7 +7,6 @@ using Microsoft.PowerPlatform.PowerApps.Persistence.Collections;
 using Microsoft.PowerPlatform.PowerApps.Persistence.Extensions;
 using Microsoft.PowerPlatform.PowerApps.Persistence.Templates;
 using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.Callbacks;
 
 namespace Microsoft.PowerPlatform.PowerApps.Persistence.Models;
 

--- a/src/Persistence/Models/Control.cs
+++ b/src/Persistence/Models/Control.cs
@@ -91,55 +91,8 @@ public abstract record Control
     }
 
 
-    [OnDeserialized]
-    internal virtual void AfterDeserialize()
-    {
-        // Apply a descending ZIndex value for each child
-        if (Children == null)
-            return;
-
-        if (this is App)
-            return; // Apps do not place ZIndex on their Host child
-
-
-        var zindexCalc = (int i) => Children.Count - i;
-        // For group containers, ZIndex is the actual order of what is shown in the tree view, not descending.
-        // Handle that here to ensure we match what is expected
-        if (Template.Name == BuiltInTemplates.GroupContainer)
-        {
-            zindexCalc = (int i) => i + 1;
-        }
-
-        for (var i = 0; i < Children.Count; i++)
-        {
-            var zIndex = zindexCalc(i);
-            Children[i].Properties[PropertyNames.ZIndex] = new ControlProperty(PropertyNames.ZIndex, zIndex.ToString(CultureInfo.InvariantCulture));
-        }
-    }
-
     internal virtual void AfterCreate(Dictionary<string, object?> controlDefinition)
     {
-    }
-
-    [OnSerializing]
-    internal void BeforeSerialize()
-    {
-        HideNestedTemplates();
-
-        Comparison<Control> zIndexComparison = (Control c1, Control c2) => c2.ZIndex.CompareTo(c1.ZIndex);
-
-        // For group containers, ZIndex is the reverse order of what is shown in the tree view
-        // Handle that here to ensure we match what is expected
-        if (Template.Name == BuiltInTemplates.GroupContainer)
-        {
-            zIndexComparison = (Control c1, Control c2) => c1.ZIndex.CompareTo(c2.ZIndex);
-        }
-
-
-        if (_children != null)
-            _children.Sort(zIndexComparison);
-
-        Properties.Remove(PropertyNames.ZIndex);
     }
 
     /// <summary>

--- a/src/Persistence/Models/Control.cs
+++ b/src/Persistence/Models/Control.cs
@@ -2,13 +2,10 @@
 // Licensed under the MIT License.
 
 using System.Diagnostics.CodeAnalysis;
-using System.Globalization;
 using Microsoft.PowerPlatform.PowerApps.Persistence.Collections;
-using Microsoft.PowerPlatform.PowerApps.Persistence.Extensions;
 using Microsoft.PowerPlatform.PowerApps.Persistence.Templates;
 using Microsoft.PowerPlatform.PowerApps.Persistence.Yaml;
 using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.Callbacks;
 
 namespace Microsoft.PowerPlatform.PowerApps.Persistence.Models;
 

--- a/src/Persistence/Models/CustomProperty.cs
+++ b/src/Persistence/Models/CustomProperty.cs
@@ -52,16 +52,4 @@ public record CustomProperty
         Function,
         Action
     }
-
-    [OnDeserialized]
-    internal void AfterDeserialize()
-    {
-        if (Parameters != null)
-        {
-            foreach (var kv in Parameters)
-            {
-                kv.Value.Name = kv.Key;
-            }
-        }
-    }
 }

--- a/src/Persistence/Models/CustomProperty.cs
+++ b/src/Persistence/Models/CustomProperty.cs
@@ -3,7 +3,6 @@
 
 using Microsoft.PowerPlatform.PowerApps.Persistence.Collections;
 using YamlDotNet.Serialization;
-using YamlDotNet.Serialization.Callbacks;
 
 namespace Microsoft.PowerPlatform.PowerApps.Persistence.Models;
 

--- a/src/Persistence/Yaml/CustomPropertiesCollectionConverter.cs
+++ b/src/Persistence/Yaml/CustomPropertiesCollectionConverter.cs
@@ -36,6 +36,15 @@ public class CustomPropertiesCollectionConverter : IYamlTypeConverter
             var value = ValueDeserializer!.DeserializeValue(parser, typeof(CustomProperty), null!, ValueDeserializer) as CustomProperty;
             if (value == null)
                 throw new YamlException(parser.Current!.Start, parser.Current.End, $"Expected custom property '{key.Value}' value");
+
+            if (value.Parameters != null)
+            {
+                foreach (var paramKv in value.Parameters)
+                {
+                    paramKv.Value.Name = paramKv.Key;
+                }
+            }
+
             value.Name = key.Value;
             collection.Add(key.Value, value);
         }


### PR DESCRIPTION
`Control`'s `[OnSerializing]` and `[OnDeserialized]` hooks are redundant, as that logic is also in `ControlFormatter.BeforeSerialize()` and `ControlFormatter.AfterDeserialize()`, which is called by the [`ControlConverter`](https://github.com/microsoft/PowerApps-Language-Tooling/blob/ecd502f229b7211ce4d70c313a42e6d272c9ce03/src/Persistence/Yaml/ControlConverter.cs)

`Component`'s `[OnDeserialized]` logic is likewise performed in [`CustomPropertiesCollectionConverter`](https://github.com/microsoft/PowerApps-Tooling/blob/ecd502f229b7211ce4d70c313a42e6d272c9ce03/src/Persistence/Yaml/CustomPropertiesCollectionConverter.cs)
and this PR also moves `CustomProperty`'s `[OnDeserialized]` logic to the same

For future work converting this current top-level OM to the new one, the same logic in `ControlFormatter` should be reusable to target the new OM, but no similar extraction has been done for the Component & its CustomProperties values