### PR TITLE
Add Layout to schema and PaYaml OM

### DIFF
--- a/schemas/pa-yaml/v2.2/pa.schema.yaml
+++ b/schemas/pa-yaml/v2.2/pa.schema.yaml
@@ -46,14 +46,17 @@ definitions:
     type: object
     propertyNames: { $ref: "#/definitions/Screen-name" }
     additionalProperties:
-      type: object
-      additionalProperties: false
-      properties:
-        Properties: { $ref: "#/definitions/Properties-formula-map" }
-        Children: { $ref: "#/definitions/Children-Control-instance-sequence" }
+      $ref: "#/definitions/Screens-instance"
 
   Screen-name:
     $ref: "#/definitions/entity-name"
+
+  Screens-instance:
+    type: object
+    additionalProperties: false
+    properties:
+      Properties: { $ref: "#/definitions/Properties-formula-map" }
+      Children: { $ref: "#/definitions/Children-Control-instance-sequence" }
 
   Children-Control-instance-sequence:
     description: >-
@@ -77,6 +80,7 @@ definitions:
     properties:
       Control: { $ref: "#/definitions/Control-type-identifier" }
       Variant: { $ref: "#/definitions/Control-variant-name" }
+      Layout: { $ref: "#/definitions/Control-layout-name" }
       Properties: { $ref: "#/definitions/Properties-formula-map" }
       Children: { $ref: "#/definitions/Children-Control-instance-sequence" }
     if:
@@ -85,21 +89,22 @@ definitions:
         Control: { $ref: "#/definitions/Control-type-component" }
     then:
       required: [ComponentName]
+      additionalProperties: false
       properties:
         Control: true
         ComponentLibraryUniqueName: { $ref: "#/definitions/ComponentLibrary-unique-name" }
         ComponentName: { $ref: "#/definitions/ComponentDefinition-name" }
         Properties: true
         # Note: Component instances do not support Variants or Children.
-      additionalProperties: false
     else:
       # Expected to be a built-in control library template
+      additionalProperties: false
       properties:
         Control: true
         Variant: true
+        Layout: true
         Properties: true
         Children: true
-      additionalProperties: false
 
   Control-type-identifier:
     description: The invariant type of control being instantiated.
@@ -132,6 +137,11 @@ definitions:
 
   Control-variant-name:
     description: The variant of a control template being instantiated.
+    allOf:
+      - $ref: "#/definitions/entity-name"
+
+  Control-layout-name:
+    description: The layout for a control which supports it.
     allOf:
       - $ref: "#/definitions/entity-name"
 

--- a/src/Persistence.Tests/PaYaml/Serialization/PaYamlSerializerTests.cs
+++ b/src/Persistence.Tests/PaYaml/Serialization/PaYamlSerializerTests.cs
@@ -110,6 +110,9 @@ public class PaYamlSerializerTests : VSTestBase
     [DataRow(@"_TestData/SchemaV2_2/Examples/Src/Screens/ComponentsScreen4.pa.yaml")]
     [DataRow(@"_TestData/SchemaV2_2/Examples/Src/Components/MyHeaderComponent.pa.yaml")]
     [DataRow(@"_TestData/SchemaV2_2/Examples/Single-File-App.pa.yaml")]
+    [DataRow(@"_TestData/SchemaV2_2/FullSchemaUses/App.pa.yaml")]
+    [DataRow(@"_TestData/SchemaV2_2/FullSchemaUses/Screens-general-controls.pa.yaml")]
+    [DataRow(@"_TestData/SchemaV2_2/FullSchemaUses/Screens-with-components.pa.yaml")]
     public void RoundTripFromYaml(string path)
     {
         var originalYaml = File.ReadAllText(path);

--- a/src/Persistence.Tests/Persistence.Tests.csproj
+++ b/src/Persistence.Tests/Persistence.Tests.csproj
@@ -21,6 +21,9 @@
       <None Include="..\schemas-tests\pa-yaml\v2.2\Examples\**\*.yaml" LinkBase="_TestData\SchemaV2_2\Examples\">
         <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       </None>
+      <None Include="..\schemas-tests\pa-yaml\v2.2\FullSchemaUses\**\*.yaml" LinkBase="_TestData\SchemaV2_2\FullSchemaUses\">
+        <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      </None>
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Persistence/PaYaml/Models/SchemaV2_2/ControlInstance.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV2_2/ControlInstance.cs
@@ -13,6 +13,8 @@ public record ControlInstance
 
     public string? Variant { get; init; }
 
+    public string? Layout { get; init; }
+
     public string? ComponentName { get; init; }
 
     public string? ComponentLibraryUniqueName { get; init; }

--- a/src/Persistence/PaYaml/Models/SchemaV2_2/PaFileRoot.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV2_2/PaFileRoot.cs
@@ -6,6 +6,6 @@ namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.SchemaV2_2
 public record PaFileRoot
 {
     public AppInstance? App { get; init; }
-    public NamedObjectMapping<ScreenInstance> Screens { get; init; } = new();
     public NamedObjectMapping<ComponentDefinition> ComponentDefinitions { get; init; } = new();
+    public NamedObjectMapping<ScreenInstance> Screens { get; init; } = new();
 }

--- a/src/Persistence/PaYaml/Serialization/PaYamlSerializationException.cs
+++ b/src/Persistence/PaYaml/Serialization/PaYamlSerializationException.cs
@@ -9,7 +9,7 @@ namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Serialization;
 [Serializable]
 internal class PaYamlSerializationException : Exception
 {
-    public PaYamlSerializationException(string reason, PaYamlLocation? eventStart)
+    public PaYamlSerializationException(string reason, PaYamlLocation? eventStart = null)
         : this(reason, eventStart, null)
     {
     }

--- a/src/schemas-tests/pa-yaml/v2.2/FullSchemaUses/App.pa.yaml
+++ b/src/schemas-tests/pa-yaml/v2.2/FullSchemaUses/App.pa.yaml
@@ -1,0 +1,10 @@
+App:
+  Properties:
+    Prop1: =formula1
+    Prop2: =formula2
+
+  Children:
+    Host:
+      Properties:
+        HostProp1: =HostFormula1
+        HostProp2: =HostFormula2

--- a/src/schemas-tests/pa-yaml/v2.2/FullSchemaUses/Screens-general-controls.pa.yaml
+++ b/src/schemas-tests/pa-yaml/v2.2/FullSchemaUses/Screens-general-controls.pa.yaml
@@ -1,0 +1,58 @@
+Screens:
+  screenName2:
+    Properties:
+      Prop2: =screen1Prop2
+      Prop1: =screen1Prop1
+
+    Children:
+      - ctrlB:
+          Control: label
+          Variant: variantB
+          Layout: layoutB
+          Properties:
+            Prop2: =ctrlBProp2
+            Prop1: =ctrlBProp1
+
+      # Purposesly set out of name sorting order to ensure ordering is maintained
+      - ctrlA:
+          Control: label
+          Variant: variantA
+          Layout: layoutA
+          Properties:
+            Prop2: =ctrlAProp2
+            Prop1: =ctrlAProp1
+
+  screenName1:
+    Children:
+      - ctrlC:
+          Control: fooWithChildren
+          Variant: variantC
+          Layout: layoutC
+          Properties:
+            Prop2: =ctrlAProp2
+            Prop1: =ctrlAProp1
+          Children:
+            - ctrlC0:
+                Control: bar
+                Variant: variantC0
+                Layout: layoutC0
+                Properties:
+                  Prop2: =ctrlC0Prop2
+                  Prop1: =ctrlC0Prop1
+                Children:
+                  - ctrlC00:
+                      Control: car
+                      Variant: variantC00
+                      Layout: layoutC00
+            - ctrlC1:
+                Control: bar
+                Variant: variantC1
+                Layout: layoutC1
+                Properties:
+                  Prop2: =ctrlC1Prop2
+                  Prop1: =ctrlC1Prop1
+                Children:
+                  - ctrlC10:
+                      Control: dog
+                      Variant: variantC10
+                      Layout: layoutC10

--- a/src/schemas-tests/pa-yaml/v2.2/FullSchemaUses/Screens-with-components.pa.yaml
+++ b/src/schemas-tests/pa-yaml/v2.2/FullSchemaUses/Screens-with-components.pa.yaml
@@ -1,0 +1,22 @@
+Screens:
+  screenName1:
+    Properties:
+      Prop2: =screen1Prop2
+      Prop1: =screen1Prop1
+
+    Children:
+      - ctrlB:
+          Control: component
+          ComponentName: myComponent1
+          Properties:
+            Prop2: =ctrlBProp2
+            Prop1: =ctrlBProp1
+
+      # Purposesly set out of name sorting order to ensure ordering is maintained
+      - ctrlA:
+          Control: component
+          ComponentName: externComponent2
+          ComponentLibraryUniqueName: pubpref_libraryName1
+          Properties:
+            Prop2: =ctrlAProp2
+            Prop1: =ctrlAProp1

--- a/src/schemas/pa-yaml/v2.2/pa.schema.yaml
+++ b/src/schemas/pa-yaml/v2.2/pa.schema.yaml
@@ -46,14 +46,17 @@ definitions:
     type: object
     propertyNames: { $ref: "#/definitions/Screen-name" }
     additionalProperties:
-      type: object
-      additionalProperties: false
-      properties:
-        Properties: { $ref: "#/definitions/Properties-formula-map" }
-        Children: { $ref: "#/definitions/Children-Control-instance-sequence" }
+      $ref: "#/definitions/Screens-instance"
 
   Screen-name:
     $ref: "#/definitions/entity-name"
+
+  Screens-instance:
+    type: object
+    additionalProperties: false
+    properties:
+      Properties: { $ref: "#/definitions/Properties-formula-map" }
+      Children: { $ref: "#/definitions/Children-Control-instance-sequence" }
 
   Children-Control-instance-sequence:
     description: >-
@@ -77,6 +80,7 @@ definitions:
     properties:
       Control: { $ref: "#/definitions/Control-type-identifier" }
       Variant: { $ref: "#/definitions/Control-variant-name" }
+      Layout: { $ref: "#/definitions/Control-layout-name" }
       Properties: { $ref: "#/definitions/Properties-formula-map" }
       Children: { $ref: "#/definitions/Children-Control-instance-sequence" }
     if:
@@ -85,21 +89,22 @@ definitions:
         Control: { $ref: "#/definitions/Control-type-component" }
     then:
       required: [ComponentName]
+      additionalProperties: false
       properties:
         Control: true
         ComponentLibraryUniqueName: { $ref: "#/definitions/ComponentLibrary-unique-name" }
         ComponentName: { $ref: "#/definitions/ComponentDefinition-name" }
         Properties: true
         # Note: Component instances do not support Variants or Children.
-      additionalProperties: false
     else:
       # Expected to be a built-in control library template
+      additionalProperties: false
       properties:
         Control: true
         Variant: true
+        Layout: true
         Properties: true
         Children: true
-      additionalProperties: false
 
   Control-type-identifier:
     description: The invariant type of control being instantiated.
@@ -132,6 +137,11 @@ definitions:
 
   Control-variant-name:
     description: The variant of a control template being instantiated.
+    allOf:
+      - $ref: "#/definitions/entity-name"
+
+  Control-layout-name:
+    description: The layout for a control which supports it.
     allOf:
       - $ref: "#/definitions/entity-name"
 


### PR DESCRIPTION
- Added `Layout` to top-level properties of a control instance
- Reordered `Screens` and `ComponentDefinitions` in PaFileRoot so the order puts the dependencies first.