### PR TITLE
`WellKnownTemplateIds` and `AddPowerAppsPersistence` refactoring

### DIFF
--- a/samples/MSAppGenerator/AppCreator.cs
+++ b/samples/MSAppGenerator/AppCreator.cs
@@ -15,7 +15,7 @@ public class AppCreator
     private static IServiceProvider ConfigureServiceProvider()
     {
         var serviceCollection = new ServiceCollection();
-        serviceCollection.AddPowerAppsPersistence(true);
+        serviceCollection.AddPowerAppsPersistence(store => store.TESTING_ONLY_AddDefaultTemplates());
         serviceCollection.AddSingleton<IAppGeneratorFactory, AppGeneratorFactory>();
         var serviceProvider = serviceCollection.BuildServiceProvider();
         return serviceProvider;

--- a/samples/MSAppGenerator/MSAppGenerator.csproj
+++ b/samples/MSAppGenerator/MSAppGenerator.csproj
@@ -9,14 +9,11 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="YamlDotNet" Version="15.1.1" />
   </ItemGroup>
 
   <ItemGroup>
     <!-- This reference will be replaced with Nuget package reference -->
-    <Reference Include="Microsoft.PowerPlatform.PowerApps.Persistence">
-      <HintPath>..\..\bin\Debug\Persistence\Microsoft.PowerPlatform.PowerApps.Persistence.dll</HintPath>
-    </Reference>
+    <ProjectReference Include="..\..\src\Persistence\Microsoft.PowerPlatform.PowerApps.Persistence.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/MauiMsApp/MauiMsApp.csproj
+++ b/samples/MauiMsApp/MauiMsApp.csproj
@@ -61,7 +61,6 @@
 		<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.6" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.6" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
-		<PackageReference Include="YamlDotNet" Version="15.1.1" />
 	</ItemGroup>
 
 	<ItemGroup>
@@ -74,9 +73,7 @@
 
 	<ItemGroup>
       <!-- This reference will be replaced with Nuget package reference -->
-	  <Reference Include="Microsoft.PowerPlatform.PowerApps.Persistence">
-	    <HintPath>..\..\bin\Debug\Persistence\Microsoft.PowerPlatform.PowerApps.Persistence.dll</HintPath>
-	  </Reference>
+      <ProjectReference Include="..\..\src\Persistence\Microsoft.PowerPlatform.PowerApps.Persistence.csproj" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/samples/MauiMsApp/MauiProgram.cs
+++ b/samples/MauiMsApp/MauiProgram.cs
@@ -31,7 +31,7 @@ public static class MauiProgram
 
     private static MauiAppBuilder RegisterMsAppPersistence(this MauiAppBuilder mauiAppBuilder)
     {
-        mauiAppBuilder.Services.AddPowerAppsPersistence(useDefaultTemplates: true);
+        mauiAppBuilder.Services.AddPowerAppsPersistence(store => store.TESTING_ONLY_AddDefaultTemplates());
         mauiAppBuilder.Services.AddTransient<IAppGeneratorFactory, AppGeneratorFactory>();
 
         return mauiAppBuilder;

--- a/samples/Test.AppWriter/Test.AppWriter.csproj
+++ b/samples/Test.AppWriter/Test.AppWriter.csproj
@@ -21,7 +21,6 @@
     <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.4.0-alpha.22272.1" />
-    <PackageReference Include="YamlDotNet" Version="15.1.1" />
   </ItemGroup>
 
   <ItemGroup>
@@ -30,9 +29,7 @@
 
   <ItemGroup>
     <!-- This reference will be replaced with Nuget package reference -->
-    <Reference Include="Microsoft.PowerPlatform.PowerApps.Persistence">
-      <HintPath>..\..\bin\Debug\Persistence\Microsoft.PowerPlatform.PowerApps.Persistence.dll</HintPath>
-    </Reference>
+  <ProjectReference Include="..\..\src\Persistence\Microsoft.PowerPlatform.PowerApps.Persistence.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/samples.sln
+++ b/samples/samples.sln
@@ -12,7 +12,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MSAppGenerator", "MSAppGenerator\MSAppGenerator.csproj", "{FAEC3592-AFEE-483E-AB74-BEF6CDC16FB6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MSAppGenerator", "MSAppGenerator\MSAppGenerator.csproj", "{FAEC3592-AFEE-483E-AB74-BEF6CDC16FB6}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.PowerPlatform.PowerApps.Persistence", "..\src\Persistence\Microsoft.PowerPlatform.PowerApps.Persistence.csproj", "{7E63AC13-98E0-4FC5-820A-C12EF51E5D90}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -34,6 +36,10 @@ Global
 		{FAEC3592-AFEE-483E-AB74-BEF6CDC16FB6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FAEC3592-AFEE-483E-AB74-BEF6CDC16FB6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FAEC3592-AFEE-483E-AB74-BEF6CDC16FB6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7E63AC13-98E0-4FC5-820A-C12EF51E5D90}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7E63AC13-98E0-4FC5-820A-C12EF51E5D90}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7E63AC13-98E0-4FC5-820A-C12EF51E5D90}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7E63AC13-98E0-4FC5-820A-C12EF51E5D90}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Persistence.Tests/TestBase.cs
+++ b/src/Persistence.Tests/TestBase.cs
@@ -21,7 +21,8 @@ public abstract class TestBase : VSTestBase
 
     static TestBase()
     {
-        ServiceProvider = BuildServiceProvider();
+        ServiceProvider = BuildServiceProviderForPersistenceTests(
+            additionalTemplateStoreConfiguration: store => store.TESTING_ONLY_AddDefaultTemplates());
     }
 
     public TestBase()
@@ -32,19 +33,12 @@ public abstract class TestBase : VSTestBase
         ControlFactory = ServiceProvider.GetRequiredService<IControlFactory>();
     }
 
-    private static IServiceProvider BuildServiceProvider()
+    internal static IServiceProvider BuildServiceProviderForPersistenceTests(
+        Action<ControlTemplateStore>? additionalTemplateStoreConfiguration = null)
     {
         var serviceCollection = new ServiceCollection();
-        var serviceProvider = ConfigureServices(serviceCollection);
-
-        return serviceProvider;
-    }
-
-    private static IServiceProvider ConfigureServices(IServiceCollection services)
-    {
-        services.AddPowerAppsPersistence(useDefaultTemplates: true);
-
-        return services.BuildServiceProvider();
+        serviceCollection.AddPowerAppsPersistence(additionalTemplateStoreConfiguration);
+        return serviceCollection.BuildServiceProvider();
     }
 
     public static IYamlDeserializer CreateDeserializer(bool isControlIdentifiers = false, bool isTextFirst = false)

--- a/src/Persistence/Templates/BuiltInTemplates.cs
+++ b/src/Persistence/Templates/BuiltInTemplates.cs
@@ -5,18 +5,18 @@ namespace Microsoft.PowerPlatform.PowerApps.Persistence.Templates;
 
 public class BuiltInTemplates
 {
-    public static readonly (string Name, string Id) App = ("Appinfo", "http://microsoft.com/appmagic/appinfo");
-    public static readonly (string Name, string Id) Host = ("HostControl", "http://microsoft.com/appmagic/hostcontrol");
-    public static readonly (string Name, string Id) Screen = ("Screen", "http://microsoft.com/appmagic/screen");
+    public static readonly (string Name, string Id) App = ("Appinfo", WellKnownTemplateIds.AppInfo);
+    public static readonly (string Name, string Id) Host = ("HostControl", WellKnownTemplateIds.HostControl);
+    public static readonly (string Name, string Id) Screen = ("Screen", WellKnownTemplateIds.Screen);
 
-    public static readonly (string Name, string Id) Component = ("Component", "http://microsoft.com/appmagic/Component");
-    public static readonly (string Name, string Id) FunctionComponent = ("FunctionComponent", "http://microsoft.com/appmagic/FunctionComponent");
-    public static readonly (string Name, string Id) DataComponent = ("DataComponent", "http://microsoft.com/appmagic/DataComponent");
-    public static readonly (string Name, string Id) CommandComponent = ("CommandComponent", "http://microsoft.com/appmagic/CommandComponent");
+    public static readonly (string Name, string Id) Component = ("Component", WellKnownTemplateIds.Component);
+    public static readonly (string Name, string Id) FunctionComponent = ("FunctionComponent", WellKnownTemplateIds.FunctionComponent);
+    public static readonly (string Name, string Id) DataComponent = ("DataComponent", WellKnownTemplateIds.DataComponent);
+    public static readonly (string Name, string Id) CommandComponent = ("CommandComponent", WellKnownTemplateIds.CommandComponent);
 
     // Group is the legacy group container template
-    public static readonly (string Name, string Id) Group = ("Group", "http://microsoft.com/appmagic/group");
+    public static readonly (string Name, string Id) Group = ("Group", WellKnownTemplateIds.Group);
 
     // Group Container is the newer layout container template
-    public static readonly (string Name, string Id) GroupContainer = ("GroupContainer", "http://microsoft.com/appmagic/groupContainer");
+    public static readonly (string Name, string Id) GroupContainer = ("GroupContainer", WellKnownTemplateIds.GroupContainer);
 }

--- a/src/Persistence/Templates/ControlTemplate.cs
+++ b/src/Persistence/Templates/ControlTemplate.cs
@@ -62,29 +62,4 @@ public record ControlTemplate
     public ControlPropertiesCollection InputProperties { get; init; } = new();
 
     public IList<ControlTemplate>? NestedTemplates { get; init; }
-
-    public CustomComponentInfo? ComponentInfo { get; init; }
-
-    [MemberNotNullWhen(true, nameof(ComponentInfo))]
-    public bool IsCustomComponent => ComponentInfo != null;
-
-    public bool IsPcfControlTemplate { get; init; }
-
-    public class CustomComponentInfo
-    {
-        /// <summary>
-        /// The unique id (a form of guid) of the component as serialized in the app.
-        /// </summary>
-        public required string UniqueId { get; init; }
-
-        /// <summary>
-        /// The friendly identifier of the component.
-        /// </summary>
-        public required string Name { get; init; }
-
-        /// <summary>
-        /// The unique name of the component library if this component originates from a component library.
-        /// </summary>
-        public string? ComponentLibraryUniqueName { get; init; }
-    }
 }

--- a/src/Persistence/Templates/WellKnownTemplateIds.cs
+++ b/src/Persistence/Templates/WellKnownTemplateIds.cs
@@ -1,0 +1,29 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.Templates;
+
+/// <summary>
+/// A set of constant strings representing templateIds of well-known templates in the Document Server.
+/// </summary>
+/// <remarks>
+/// These often may have custom logic or handling in various parts of the codebase (e.g. attribute parameter values, etc).
+/// </remarks>
+public static class WellKnownTemplateIds
+{
+    public const string AppInfo = "http://microsoft.com/appmagic/appinfo";
+    public const string Screen = "http://microsoft.com/appmagic/screen";
+    public const string Component = "http://microsoft.com/appmagic/Component";
+    public const string CommandComponent = "http://microsoft.com/appmagic/CommandComponent";
+    public const string DataComponent = "http://microsoft.com/appmagic/DataComponent";
+    public const string FunctionComponent = "http://microsoft.com/appmagic/FunctionComponent";
+    public const string HostControl = "http://microsoft.com/appmagic/hostcontrol";
+    public const string TestSuite = "http://microsoft.com/appmagic/testsuite";
+    public const string AppTest = "http://microsoft.com/appmagic/apptest";
+    public const string TestCase = "http://microsoft.com/appmagic/testcase";
+
+    public const string Group = "http://microsoft.com/appmagic/group";
+    public const string GroupContainer = "http://microsoft.com/appmagic/groupContainer";
+    public const string Gallery = "http://microsoft.com/appmagic/gallery";
+    public const string GalleryTemplate = "http://microsoft.com/appmagic/galleryTemplate";
+}


### PR DESCRIPTION
- `WellKnownTemplateIds` constants for id's used in the persistence assembly. Updated ServiceCollectionExtensions to use these.
- `AddPowerAppsPersistence` modified:
  - accepts additional parameter for configuring template store. This allows callers unrestricted ability to build the template store removing need to add code in product implementation for testing setup logic.
  - removed parameter `useDefaultTemplates` in preference for tests to make explicit call to utility method or to do other custom logic.
  - Renamed `AddDefaultTemplates` to `TESTING_ONLY_AddDefaultTemplates` to be clear about intention of usage. Made it public so it can be called by DocServer test code directly.
- Revert "Update `ControlTemplate` to indicate whether it's a Component or Pcf control template (#631)"
- Fixed AppGenerator to use ProjectReference to Persistence.csproj to ensure correct nuget dependency validation etc.