### PR TITLE
Enable code analysis rules by category

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -134,7 +134,7 @@ csharp_style_expression_bodied_indexers = true:silent
 csharp_style_expression_bodied_accessors = true:silent
 csharp_style_expression_bodied_lambdas = true:silent
 csharp_style_expression_bodied_local_functions = false:silent
-csharp_style_var_elsewhere = true:error
+csharp_style_var_elsewhere = true:warning
 csharp_style_var_when_type_is_apparent = true:error
 csharp_style_var_for_built_in_types = true:error
 csharp_space_around_binary_operators = before_and_after
@@ -179,17 +179,17 @@ csharp_style_prefer_extended_property_pattern = true:suggestion
 # Set severity to 'error' when the fix indicates a breaking change or using insecure/unsafe APIs/patterns.
 [*.{cs,vb}]
 
-# dotnet_analyzer_diagnostic.category-Design.severity           = warning
-# dotnet_analyzer_diagnostic.category-Documentation.severity    = none
-# dotnet_analyzer_diagnostic.category-Globalization.severity    = none
-# dotnet_analyzer_diagnostic.category-Interoperability.severity = warning
-# dotnet_analyzer_diagnostic.category-Maintainability.severity  = warning
-# dotnet_analyzer_diagnostic.category-Naming.severity           = warning
-# dotnet_analyzer_diagnostic.category-Performance.severity      = warning
-# dotnet_analyzer_diagnostic.category-Reliability.severity      = warning
-# dotnet_analyzer_diagnostic.category-Security.severity         = error
+dotnet_analyzer_diagnostic.category-Design.severity           = warning
+dotnet_analyzer_diagnostic.category-Documentation.severity    = warning
+dotnet_analyzer_diagnostic.category-Globalization.severity    = warning
+dotnet_analyzer_diagnostic.category-Interoperability.severity = warning
+dotnet_analyzer_diagnostic.category-Maintainability.severity  = warning
+dotnet_analyzer_diagnostic.category-Naming.severity           = warning
+dotnet_analyzer_diagnostic.category-Performance.severity      = warning
+dotnet_analyzer_diagnostic.category-Reliability.severity      = warning
+dotnet_analyzer_diagnostic.category-Security.severity         = error
 dotnet_analyzer_diagnostic.category-Style.severity            = warning
-# dotnet_analyzer_diagnostic.category-Usage.severity            = warning
+dotnet_analyzer_diagnostic.category-Usage.severity            = warning
 
 # *********************************
 # ** Code-style Diagnostic Rules **
@@ -235,23 +235,23 @@ dotnet_diagnostic.IDE1006.severity = none       # These words must begin with up
 [*.{cs,vb}]
 
 dotnet_diagnostic.CA1507.severity = error   # Use nameof in place of string
-dotnet_diagnostic.CA1508.severity = error   # Avoid dead conditional code
+dotnet_diagnostic.CA1508.severity = warning # Avoid dead conditional code
 dotnet_diagnostic.CA1700.severity = error   # Do not name enum values 'Reserved'
-dotnet_diagnostic.CA1707.severity = error   # Identifiers should not contain underscores
+dotnet_diagnostic.CA1707.severity = warning # Identifiers should not contain underscores
 dotnet_diagnostic.CA1708.severity = error   # Identifiers should differ by more than case
 dotnet_diagnostic.CA1710.severity = error   # Identifiers should have correct suffix
 dotnet_diagnostic.CA1712.severity = error   # Do not prefix enum values with type name
 dotnet_diagnostic.CA1720.severity = error   # Identifiers should not contain type names
 dotnet_diagnostic.CA1802.severity = error   # Use Literals Where Appropriate
-dotnet_diagnostic.CA1805.severity = error   # Do not initialize unnecessarily
+dotnet_diagnostic.CA1805.severity = warning # Do not initialize unnecessarily
 dotnet_diagnostic.CA1810.severity = error   # Initialize reference type static fields inline
 dotnet_diagnostic.CA1821.severity = error   # Remove empty finalizers
-dotnet_diagnostic.CA1822.severity = error   # Mark members as static
-dotnet_diagnostic.CA1823.severity = error   # Avoid unused private fields
-dotnet_diagnostic.CA1826.severity = error   # Use property instead of Linq Enumerable method
-dotnet_diagnostic.CA1827.severity = error   # Do not use Count()/LongCount() when Any() can be used
-dotnet_diagnostic.CA1849.severity = error   # Call async methods when in an async method
-dotnet_diagnostic.CA2000.severity = error   # Dispose objects before losing scope
+dotnet_diagnostic.CA1822.severity = warning # Mark members as static
+dotnet_diagnostic.CA1823.severity = warning # Avoid unused private fields
+dotnet_diagnostic.CA1826.severity = warning # Use property instead of Linq Enumerable method
+dotnet_diagnostic.CA1827.severity = warning # Do not use Count()/LongCount() when Any() can be used
+dotnet_diagnostic.CA1849.severity = warning # Call async methods when in an async method
+dotnet_diagnostic.CA2000.severity = warning # Dispose objects before losing scope
 
 
 # *****************************************
@@ -646,6 +646,9 @@ dotnet_diagnostic.SA1648.severity = none
 dotnet_diagnostic.SA1649.severity = none
 
 dotnet_diagnostic.SA1651.severity = none
+
+# SYSLIB1045: Convert to 'GeneratedRegexAttribute'.
+dotnet_diagnostic.SYSLIB1045.severity = none # Seems to be an IDE only rule atm
 
 dotnet_diagnostic.SX1309.severity = none
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -261,8 +261,6 @@ dotnet_diagnostic.CA2000.severity = warning # Dispose objects before losing scop
 # Note: The VS IDE generates these by placing the rule type name on the previous line, instead of on the same line.
 [*.{cs,vb}]
 
-dotnet_diagnostic.SA0001.severity = none
-
 dotnet_diagnostic.SA0002.severity = error
 
 dotnet_diagnostic.SA1000.severity = error
@@ -288,46 +286,7 @@ dotnet_diagnostic.SA1009.severity = error
 
 dotnet_diagnostic.SA1010.severity = error
 
-dotnet_diagnostic.SA1011.severity = none
-
-dotnet_diagnostic.SA1012.severity = none
-
-dotnet_diagnostic.SA1013.severity = none
-
-dotnet_diagnostic.SA1014.severity = none
-
-dotnet_diagnostic.SA1015.severity = none
-
-dotnet_diagnostic.SA1016.severity = none
-
-dotnet_diagnostic.SA1017.severity = none
-
-dotnet_diagnostic.SA1018.severity = none
-
-dotnet_diagnostic.SA1019.severity = none
-
-dotnet_diagnostic.SA1020.severity = none
-
-dotnet_diagnostic.SA1021.severity = none
-
-dotnet_diagnostic.SA1022.severity = none
-
-dotnet_diagnostic.SA1023.severity = none
-
-dotnet_diagnostic.SA1024.severity = none
-
-dotnet_diagnostic.SA1025.severity = none
-
-dotnet_diagnostic.SA1026.severity = none
-
-dotnet_diagnostic.SA1027.severity = none
-
-# Code should not contain trailing whitespace
-dotnet_diagnostic.SA1028.severity = none
-
 dotnet_diagnostic.SA1100.severity = error
-
-dotnet_diagnostic.SA1101.severity = none
 
 dotnet_diagnostic.SA1102.severity = error
 
@@ -337,11 +296,7 @@ dotnet_diagnostic.SA1104.severity = error
 
 dotnet_diagnostic.SA1105.severity = error
 
-dotnet_diagnostic.SA1106.severity = none
-
 dotnet_diagnostic.SA1107.severity = error
-
-dotnet_diagnostic.SA1108.severity = none
 
 # OpeningParenthesisMustBeOnDeclarationLine
 dotnet_diagnostic.SA1110.severity = error
@@ -367,25 +322,11 @@ dotnet_diagnostic.SA1116.severity = error
 # ParametersMustBeOnSameLineOrSeparateLines
 dotnet_diagnostic.SA1117.severity = error
 
-# ParameterMustNotSpanMultipleLines. Not enforced now
-dotnet_diagnostic.SA1118.severity = none
-
-dotnet_diagnostic.SA1119.severity = none
-
 # GenericTypeConstraintsMustBeOnOwnLine
 dotnet_diagnostic.SA1120.severity = error
 
-# UseBuiltInTypeAlias
-dotnet_diagnostic.SA1121.severity = none
-
-# UseStringEmptyForEmptyStrings
-dotnet_diagnostic.SA1122.severity = none
-
 # DoNotPlaceRegionsWithinElements
 dotnet_diagnostic.SA1123.severity = error
-
-# DoNotUseRegions
-dotnet_diagnostic.SA1124.severity = none
 
 # UseShorthandForNullableTypes
 dotnet_diagnostic.SA1125.severity = error
@@ -420,232 +361,21 @@ dotnet_diagnostic.SA1135.severity = error
 # EnumValuesShouldBeOnSeparateLines
 dotnet_diagnostic.SA1136.severity = error
 
-# ElementsShouldHaveTheSameIndentation
-dotnet_diagnostic.SA1137.severity = none
-
 # UseLiteralsSuffixNotationInsteadOfCasting
 dotnet_diagnostic.SA1139.severity = error
-
-dotnet_diagnostic.SA1200.severity = none
-
-# ElementsMustAppearInTheCorrectOrder (This is a good rule, but not followed in the code currently)
-dotnet_diagnostic.SA1201.severity = none
-
-# Same
-dotnet_diagnostic.SA1202.severity = none
-
-# Same
-dotnet_diagnostic.SA1203.severity = none
-
-# Same
-dotnet_diagnostic.SA1204.severity = none
-
-dotnet_diagnostic.SA1205.severity = none
-
-dotnet_diagnostic.SA1206.severity = none
-
-dotnet_diagnostic.SA1207.severity = none
-
-dotnet_diagnostic.SA1208.severity = none
-
-dotnet_diagnostic.SA1209.severity = none
-
-dotnet_diagnostic.SA1210.severity = none
-
-dotnet_diagnostic.SA1211.severity = none
-
-dotnet_diagnostic.SA1212.severity = none
-
-dotnet_diagnostic.SA1213.severity = none
-
-dotnet_diagnostic.SA1214.severity = none
-
-dotnet_diagnostic.SA1216.severity = none
-
-dotnet_diagnostic.SA1217.severity = none
-
-dotnet_diagnostic.SA1300.severity = none
 
 # InterfaceNamesMustBeginWithI
 dotnet_diagnostic.SA1302.severity = error
 
-dotnet_diagnostic.SA1303.severity = none
-
-dotnet_diagnostic.SA1304.severity = none
-
-dotnet_diagnostic.SA1305.severity = none
-
-dotnet_diagnostic.SA1306.severity = none
-
-dotnet_diagnostic.SA1307.severity = none
-
 # VariableNamesMustNotBePrefixed
 dotnet_diagnostic.SA1308.severity = error
-
-dotnet_diagnostic.SA1309.severity = none
-
-dotnet_diagnostic.SA1310.severity = none
-
-dotnet_diagnostic.SA1311.severity = none
-
-dotnet_diagnostic.SA1312.severity = none
 
 # ParameterNamesMustBeginWithLowerCaseLetter
 dotnet_diagnostic.SA1313.severity = error
 
-dotnet_diagnostic.SA1314.severity = none
-
-dotnet_diagnostic.SA1400.severity = none
-
-dotnet_diagnostic.SA1401.severity = none
-
 # End XM Documentation Warnings
 # File/Class Naming Guidelines: These conflict with our function files mostly
 dotnet_diagnostic.SA1402.severity = none
-
-dotnet_diagnostic.SA1403.severity = none
-
-dotnet_diagnostic.SA1404.severity = none
-
-dotnet_diagnostic.SA1405.severity = none
-
-dotnet_diagnostic.SA1406.severity = none
-
-dotnet_diagnostic.SA1407.severity = none
-
-dotnet_diagnostic.SA1408.severity = none
-
-dotnet_diagnostic.SA1410.severity = none
-
-dotnet_diagnostic.SA1411.severity = none
-
-dotnet_diagnostic.SA1412.severity = none
-
-dotnet_diagnostic.SA1413.severity = none
-
-dotnet_diagnostic.SA1500.severity = none
-
-dotnet_diagnostic.SA1501.severity = none
-
-dotnet_diagnostic.SA1502.severity = none
-
-dotnet_diagnostic.SA1503.severity = none
-
-dotnet_diagnostic.SA1504.severity = none
-
-dotnet_diagnostic.SA1505.severity = none
-
-dotnet_diagnostic.SA1506.severity = none
-
-dotnet_diagnostic.SA1507.severity = none
-
-dotnet_diagnostic.SA1508.severity = none
-
-dotnet_diagnostic.SA1509.severity = none
-
-dotnet_diagnostic.SA1510.severity = none
-
-dotnet_diagnostic.SA1511.severity = none
-
-dotnet_diagnostic.SA1512.severity = none
-
-dotnet_diagnostic.SA1513.severity = none
-
-dotnet_diagnostic.SA1514.severity = none
-
-dotnet_diagnostic.SA1515.severity = none
-
-dotnet_diagnostic.SA1516.severity = none
-
-dotnet_diagnostic.SA1517.severity = none
-
-dotnet_diagnostic.SA1518.severity = none
-
-dotnet_diagnostic.SA1519.severity = none
-
-dotnet_diagnostic.SA1520.severity = none
-
-dotnet_diagnostic.SA1600.severity = none
-
-dotnet_diagnostic.SA1601.severity = none
-
-dotnet_diagnostic.SA1602.severity = none
-
-dotnet_diagnostic.SA1604.severity = none
-
-dotnet_diagnostic.SA1605.severity = none
-
-dotnet_diagnostic.SA1606.severity = none
-
-dotnet_diagnostic.SA1607.severity = none
-
-dotnet_diagnostic.SA1608.severity = none
-
-dotnet_diagnostic.SA1609.severity = none
-
-dotnet_diagnostic.SA1610.severity = none
-
-dotnet_diagnostic.SA1611.severity = none
-
-dotnet_diagnostic.SA1612.severity = none
-
-dotnet_diagnostic.SA1613.severity = none
-
-dotnet_diagnostic.SA1614.severity = none
-
-dotnet_diagnostic.SA1615.severity = none
-
-dotnet_diagnostic.SA1616.severity = none
-
-dotnet_diagnostic.SA1617.severity = none
-
-dotnet_diagnostic.SA1618.severity = none
-
-dotnet_diagnostic.SA1619.severity = none
-
-dotnet_diagnostic.SA1620.severity = none
-
-dotnet_diagnostic.SA1621.severity = none
-
-dotnet_diagnostic.SA1622.severity = none
-
-dotnet_diagnostic.SA1623.severity = none
-
-dotnet_diagnostic.SA1624.severity = none
-
-dotnet_diagnostic.SA1625.severity = none
-
-dotnet_diagnostic.SA1626.severity = none
-
-dotnet_diagnostic.SA1627.severity = none
-
-dotnet_diagnostic.SA1629.severity = none
-
-dotnet_diagnostic.SA1633.severity = none
-
-dotnet_diagnostic.SA1634.severity = none
-
-dotnet_diagnostic.SA1635.severity = none
-
-dotnet_diagnostic.SA1636.severity = none
-
-dotnet_diagnostic.SA1637.severity = none
-
-dotnet_diagnostic.SA1638.severity = none
-
-dotnet_diagnostic.SA1640.severity = none
-
-dotnet_diagnostic.SA1641.severity = none
-
-dotnet_diagnostic.SA1642.severity = none
-
-dotnet_diagnostic.SA1643.severity = none
-
-dotnet_diagnostic.SA1648.severity = none
-
-dotnet_diagnostic.SA1649.severity = none
-
-dotnet_diagnostic.SA1651.severity = none
 
 # SYSLIB1045: Convert to 'GeneratedRegexAttribute'.
 dotnet_diagnostic.SYSLIB1045.severity = none # Seems to be an IDE only rule atm

--- a/samples/MSAppGenerator/MSAppGenerator.csproj
+++ b/samples/MSAppGenerator/MSAppGenerator.csproj
@@ -8,15 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
-    <PackageReference Include="YamlDotNet" Version="15.1.1" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <!-- This reference will be replaced with Nuget package reference -->
-    <Reference Include="Microsoft.PowerPlatform.PowerApps.Persistence">
-      <HintPath>..\..\bin\Debug\Persistence\Microsoft.PowerPlatform.PowerApps.Persistence.dll</HintPath>
-    </Reference>
+    <ProjectReference Include="..\..\src\Persistence\Microsoft.PowerPlatform.PowerApps.Persistence.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/MauiMsApp/MauiMsApp.csproj
+++ b/samples/MauiMsApp/MauiMsApp.csproj
@@ -61,23 +61,12 @@
 		<PackageReference Include="Microsoft.Maui.Controls" Version="8.0.6" />
 		<PackageReference Include="Microsoft.Maui.Controls.Compatibility" Version="8.0.6" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="8.0.0" />
-		<PackageReference Include="YamlDotNet" Version="15.1.1" />
 	</ItemGroup>
 
 	<ItemGroup>
 	  <ProjectReference Include="..\MSAppGenerator\MSAppGenerator.csproj" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <ProjectReference Include="..\MSAppGenerator\MSAppGenerator.csproj" />
-	</ItemGroup>
-
-	<ItemGroup>
-      <!-- This reference will be replaced with Nuget package reference -->
-	  <Reference Include="Microsoft.PowerPlatform.PowerApps.Persistence">
-	    <HintPath>..\..\bin\Debug\Persistence\Microsoft.PowerPlatform.PowerApps.Persistence.dll</HintPath>
-	  </Reference>
-	</ItemGroup>
+    <ProjectReference Include="..\..\src\Persistence\Microsoft.PowerPlatform.PowerApps.Persistence.csproj" />
+  </ItemGroup>
 
 	<ItemGroup>
 	  <Compile Update="CreatePage.xaml.cs">

--- a/samples/Test.AppWriter/InputProcessor.cs
+++ b/samples/Test.AppWriter/InputProcessor.cs
@@ -6,7 +6,7 @@ using MSAppGenerator;
 
 namespace Test.AppWriter;
 
-internal class InputProcessor
+internal sealed class InputProcessor
 {
     /// <summary>
     /// Validate that the provided filepath is accessible and not an existing file

--- a/samples/Test.AppWriter/Program.cs
+++ b/samples/Test.AppWriter/Program.cs
@@ -5,7 +5,7 @@ using System.CommandLine;
 
 namespace Test.AppWriter;
 
-internal class Program
+internal sealed class Program
 {
     private static void Main(string[] args)
     {

--- a/samples/Test.AppWriter/Test.AppWriter.csproj
+++ b/samples/Test.AppWriter/Test.AppWriter.csproj
@@ -18,21 +18,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     <PackageReference Include="System.CommandLine.DragonFruit" Version="0.4.0-alpha.22272.1" />
-    <PackageReference Include="YamlDotNet" Version="15.1.1" />
   </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\MSAppGenerator\MSAppGenerator.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <!-- This reference will be replaced with Nuget package reference -->
-    <Reference Include="Microsoft.PowerPlatform.PowerApps.Persistence">
-      <HintPath>..\..\bin\Debug\Persistence\Microsoft.PowerPlatform.PowerApps.Persistence.dll</HintPath>
-    </Reference>
+    <ProjectReference Include="..\..\src\Persistence\Microsoft.PowerPlatform.PowerApps.Persistence.csproj" />
   </ItemGroup>
 
 </Project>

--- a/samples/samples.sln
+++ b/samples/samples.sln
@@ -12,7 +12,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		README.md = README.md
 	EndProjectSection
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MSAppGenerator", "MSAppGenerator\MSAppGenerator.csproj", "{FAEC3592-AFEE-483E-AB74-BEF6CDC16FB6}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MSAppGenerator", "MSAppGenerator\MSAppGenerator.csproj", "{FAEC3592-AFEE-483E-AB74-BEF6CDC16FB6}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.PowerPlatform.PowerApps.Persistence", "..\src\Persistence\Microsoft.PowerPlatform.PowerApps.Persistence.csproj", "{E46ED508-752B-4197-AC32-293DAE28A3E2}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -34,6 +36,10 @@ Global
 		{FAEC3592-AFEE-483E-AB74-BEF6CDC16FB6}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FAEC3592-AFEE-483E-AB74-BEF6CDC16FB6}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FAEC3592-AFEE-483E-AB74-BEF6CDC16FB6}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E46ED508-752B-4197-AC32-293DAE28A3E2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E46ED508-752B-4197-AC32-293DAE28A3E2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E46ED508-752B-4197-AC32-293DAE28A3E2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E46ED508-752B-4197-AC32-293DAE28A3E2}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/PAModel/.editorconfig
+++ b/src/PAModel/.editorconfig
@@ -1,3 +1,13 @@
 [*.cs]
 
+# Category overries:
+# Disabling these categories because the original implementation didn't have them on and we're not making changes to it at this time.
+dotnet_analyzer_diagnostic.category-Design.severity           = silent
+dotnet_analyzer_diagnostic.category-Globalization.severity    = silent
+dotnet_analyzer_diagnostic.category-Performance.severity      = silent
+dotnet_analyzer_diagnostic.category-Usage.severity            = silent
+
 # Rule overrides:
+
+# CA1716: Identifiers should not match keywords
+dotnet_diagnostic.CA1716.severity = silent

--- a/src/PAModelTests/.editorconfig
+++ b/src/PAModelTests/.editorconfig
@@ -1,3 +1,9 @@
-[*.cs]
+﻿[*.cs]
+
+# Category overries:
+# Disabling these categories because the original implementation didn't have them on and we're not making changes to it at this time.
+dotnet_analyzer_diagnostic.category-Globalization.severity    = silent
+dotnet_analyzer_diagnostic.category-Performance.severity      = silent
+dotnet_analyzer_diagnostic.category-Usage.severity            = silent
 
 # Rule overrides:

--- a/src/PASopa/.editorconfig
+++ b/src/PASopa/.editorconfig
@@ -1,3 +1,8 @@
 [*.cs]
 
+# Category overries:
+# Disabling these categories because the original implementation didn't have them on and we're not making changes to it at this time.
+dotnet_analyzer_diagnostic.category-Globalization.severity    = silent
+dotnet_analyzer_diagnostic.category-Performance.severity      = silent
+
 # Rule overrides:

--- a/src/Persistence.Tests/Extensions/PersistenceFluentExtensions.cs
+++ b/src/Persistence.Tests/Extensions/PersistenceFluentExtensions.cs
@@ -2,6 +2,7 @@
 // Licensed under the MIT License.
 
 using System.Diagnostics.CodeAnalysis;
+using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
 using FluentAssertions.Execution;
@@ -256,7 +257,7 @@ internal static class PersistenceFluentExtensions
         var line = reader.ReadLine();
         while (line is not null)
         {
-            sb.AppendLine($"{lineNumber,3}: {line}");
+            sb.AppendLine(CultureInfo.InvariantCulture, $"{lineNumber,3}: {line}");
             line = reader.ReadLine();
             lineNumber++;
         }

--- a/src/Persistence.Tests/TestBase.cs
+++ b/src/Persistence.Tests/TestBase.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Globalization;
 using Microsoft.PowerPlatform.PowerApps.Persistence.Extensions;
 using Microsoft.PowerPlatform.PowerApps.Persistence.Models;
 using Microsoft.PowerPlatform.PowerApps.Persistence.MsApp;
@@ -73,7 +74,7 @@ public abstract class TestBase : VSTestBase
 
     public static string GetTestFilePath(string path, bool isControlIdentifiers = false)
     {
-        return string.Format(path, isControlIdentifiers ? "-CI" : string.Empty);
+        return string.Format(CultureInfo.InvariantCulture, path, isControlIdentifiers ? "-CI" : string.Empty);
     }
 
     public static IEnumerable<object[]> ComponentCustomProperties_Data => new List<object[]>()

--- a/src/Persistence.Tests/Yaml/ZIndexOrderingTests.cs
+++ b/src/Persistence.Tests/Yaml/ZIndexOrderingTests.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Globalization;
 using Microsoft.PowerPlatform.PowerApps.Persistence.Models;
 using Microsoft.PowerPlatform.PowerApps.Persistence.Yaml;
 
@@ -201,7 +202,7 @@ public class ZIndexOrderingTests : TestBase
             properties:
             new()
             {
-                { PropertyNames.ZIndex, i.ToString() },
+                { PropertyNames.ZIndex, i.ToString(CultureInfo.InvariantCulture) },
             });
     }
 }

--- a/src/Persistence/.editorconfig
+++ b/src/Persistence/.editorconfig
@@ -1,3 +1,6 @@
-﻿[*.cs]
+[*.cs]
 
 # Rule overrides:
+
+# CA1848: Use the LoggerMessage delegates
+dotnet_diagnostic.CA1848.severity = silent # Not implementing LoggerMessage pattern yet

--- a/src/Persistence/Collections/ControlPropertiesCollection.cs
+++ b/src/Persistence/Collections/ControlPropertiesCollection.cs
@@ -46,7 +46,7 @@ public class ControlPropertiesCollection : NamedItemsCollection<ControlProperty>
     public void Add(Tuple<string, string> keyValue)
     {
         if (string.IsNullOrWhiteSpace(keyValue.Item1))
-            throw new ArgumentNullException(nameof(keyValue.Item1));
+            throw new ArgumentNullException(nameof(keyValue), "The key cannot be null or whitespace.");
 
         Add(keyValue.Item1, new ControlProperty(keyValue.Item1, keyValue.Item2));
     }

--- a/src/Persistence/Collections/NamedItemsCollection.cs
+++ b/src/Persistence/Collections/NamedItemsCollection.cs
@@ -76,19 +76,19 @@ public abstract class NamedItemsCollection<TValue> :
     {
         get
         {
-            if (key is string s)
-                return _items[s];
-            throw new ArgumentException();
+            if (key is not string s)
+                throw new ArgumentException("Key must be a string", nameof(key));
+
+            return _items[s];
         }
         set
         {
-            if (key is string s && value is TValue v)
-            {
-                _items[s] = v;
-                return;
-            }
+            if (key is not string s)
+                throw new ArgumentException("Key must be a string", nameof(key));
+            if (key is not TValue v)
+                throw new ArgumentException($"Value must be of type {typeof(TValue).Name}", nameof(value));
 
-            throw new ArgumentException();
+            _items[s] = v;
         }
     }
 
@@ -112,16 +112,19 @@ public abstract class NamedItemsCollection<TValue> :
         _items.Add(key, value);
     }
 
-    public void Add(KeyValuePair<string, TValue> kv)
+    public void Add(KeyValuePair<string, TValue> item)
     {
-        _items.Add(kv.Key, kv.Value);
+        _items.Add(item.Key, item.Value);
     }
 
     public void Add(object key, object? value)
     {
-        if (key is string s && value is TValue v)
-            Add(s, v);
-        throw new ArgumentException();
+        if (key is not string s)
+            throw new ArgumentException("Key must be a string", nameof(key));
+        if (key is not TValue v)
+            throw new ArgumentException($"Value must be of type {typeof(TValue).Name}", nameof(value));
+
+        Add(s, v);
     }
 
     public bool TryGetValue(string key, [MaybeNullWhen(false)] out TValue value)
@@ -183,7 +186,7 @@ public abstract class NamedItemsCollection<TValue> :
         if (key is TValue v)
             return ContainsKey(_keySelector(v));
 
-        throw new ArgumentException();
+        throw new ArgumentException($"Key must be a string or of type {typeof(TValue).Name}", nameof(key));
     }
 
     public void Remove(object key)

--- a/src/Persistence/Extensions/ListExtensions.cs
+++ b/src/Persistence/Extensions/ListExtensions.cs
@@ -53,15 +53,15 @@ public class ComparisonComparer<T> : IComparer<T>, IComparer
         return _comparison(x, y);
     }
 
-    public int Compare(object? o1, object? o2)
+    public int Compare(object? x, object? y)
     {
-        if (o1 == null && o2 == null)
+        if (x == null && y == null)
             return 0;
-        if (o1 == null)
+        if (x == null)
             return -1;
-        if (o2 == null)
+        if (y == null)
             return 1;
 
-        return _comparison((T)o1, (T)o2);
+        return _comparison((T)x, (T)y);
     }
 }

--- a/src/Persistence/Extensions/StringExtensions.cs
+++ b/src/Persistence/Extensions/StringExtensions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Globalization;
+
 namespace Microsoft.PowerPlatform.PowerApps.Persistence.Extensions;
 public static class StringExtensions
 {
@@ -9,8 +11,22 @@ public static class StringExtensions
         if (string.IsNullOrWhiteSpace(input))
             return input;
 
-        var first = char.ToUpper(input[0]);
+        var first = char.ToUpper(input[0], CultureInfo.InvariantCulture);
         var rest = input.AsSpan(1);
         return string.Concat(new ReadOnlySpan<char>(first), rest);
+    }
+
+    public static bool StartsWithInvariant(this string input, string value)
+    {
+        _ = input ?? throw new ArgumentNullException(nameof(input));
+
+        return input.StartsWith(value, StringComparison.InvariantCulture);
+    }
+
+    public static bool StartsWithOrdinal(this string input, string value)
+    {
+        _ = input ?? throw new ArgumentNullException(nameof(input));
+
+        return input.StartsWith(value, StringComparison.Ordinal);
     }
 }

--- a/src/Persistence/Models/AppTemplates.cs
+++ b/src/Persistence/Models/AppTemplates.cs
@@ -8,7 +8,7 @@ namespace Microsoft.PowerPlatform.PowerApps.Persistence.Models;
 /// <summary>
 /// App Templates
 /// </summary>
-internal record AppTemplates
+internal sealed record AppTemplates
 {
     [SetsRequiredMembers]
     public AppTemplates()

--- a/src/Persistence/Models/AppThemes.cs
+++ b/src/Persistence/Models/AppThemes.cs
@@ -5,7 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 
 namespace Microsoft.PowerPlatform.PowerApps.Persistence.Models;
 
-internal record AppThemes
+internal sealed record AppThemes
 {
     [SetsRequiredMembers]
     public AppThemes()

--- a/src/Persistence/Models/ControlProperty.cs
+++ b/src/Persistence/Models/ControlProperty.cs
@@ -6,6 +6,7 @@ using System.Diagnostics.CodeAnalysis;
 namespace Microsoft.PowerPlatform.PowerApps.Persistence.Models;
 
 [DebuggerDisplay("{Value}")]
+[SuppressMessage("Design", "CA1036:Override methods on comparable types", Justification = "REVIEW: Author of this class should remove this suppression and fix the violation, or update this Justification message.")]
 public sealed record ControlProperty : IComparable<ControlProperty>
 {
     public const char FormulaPrefix = '=';

--- a/src/Persistence/MsApp/MsappArchive.cs
+++ b/src/Persistence/MsApp/MsappArchive.cs
@@ -74,7 +74,7 @@ public partial class MsappArchive : IMsappArchive, IDisposable
     /// <summary>
     /// Helper class for deserializing the top level control editor state.
     /// </summary>
-    private class TopParentJson
+    private sealed class TopParentJson
     {
 #pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
         public ControlEditorState? TopParent { get; set; }
@@ -296,7 +296,7 @@ public partial class MsappArchive : IMsappArchive, IDisposable
             if (entry.Key.EndsWith('/'))
                 continue;
 
-            if (directoryName != string.Empty && !entry.Key.StartsWith(directoryName + '/'))
+            if (directoryName != string.Empty && !entry.Key.StartsWith(directoryName + '/', StringComparison.InvariantCulture))
                 continue;
 
             // If not recursive, skip subdirectories

--- a/src/Persistence/PaYaml/Models/NamedObjectMappingBase.cs
+++ b/src/Persistence/PaYaml/Models/NamedObjectMappingBase.cs
@@ -48,6 +48,7 @@ public abstract class NamedObjectMappingBase<TName, TValue, TNamedObject> : INam
         }
     }
 
+    [SuppressMessage("Naming", "CA1725:Parameter names should match base declaration", Justification = "ByDesign: 'namedObject' is preferred over 'item'")]
     public void Add(TNamedObject namedObject)
     {
         InnerCollection.Add(namedObject.Name, namedObject);
@@ -76,6 +77,7 @@ public abstract class NamedObjectMappingBase<TName, TValue, TNamedObject> : INam
         return InnerCollection.ContainsKey(name);
     }
 
+    [SuppressMessage("Naming", "CA1725:Parameter names should match base declaration", Justification = "ByDesign: 'namedObject' is preferred over 'item'")]
     public bool Contains(TNamedObject namedObject)
     {
         return InnerCollection.ContainsValue(namedObject);

--- a/src/Persistence/PaYaml/Models/NamedObjectSequenceBase.cs
+++ b/src/Persistence/PaYaml/Models/NamedObjectSequenceBase.cs
@@ -37,6 +37,7 @@ public abstract class NamedObjectSequenceBase<TName, TValue, TNamedObject> : INa
 
     public TValue this[TName name] => InnerCollection[name].Value;
 
+    [SuppressMessage("Naming", "CA1725:Parameter names should match base declaration", Justification = "ByDesign: 'namedObject' is preferred over 'item'")]
     public void Add(TNamedObject namedObject)
     {
         InnerCollection.Add(namedObject);
@@ -65,6 +66,7 @@ public abstract class NamedObjectSequenceBase<TName, TValue, TNamedObject> : INa
         return InnerCollection.Contains(name);
     }
 
+    [SuppressMessage("Naming", "CA1725:Parameter names should match base declaration", Justification = "ByDesign: 'namedObject' is preferred over 'item'")]
     public bool Contains(TNamedObject namedObject)
     {
         return InnerCollection.Contains(namedObject);
@@ -145,7 +147,7 @@ public abstract class NamedObjectSequenceBase<TName, TValue, TNamedObject> : INa
         }
     }
 
-    internal class InnerKeyedCollection : KeyedCollection<TName, TNamedObject>
+    internal sealed class InnerKeyedCollection : KeyedCollection<TName, TNamedObject>
     {
         public InnerKeyedCollection(IEqualityComparer<TName>? comparer) : base(comparer)
         {

--- a/src/Persistence/PaYaml/Serialization/PaYamlSerializationException.cs
+++ b/src/Persistence/PaYaml/Serialization/PaYamlSerializationException.cs
@@ -7,7 +7,7 @@ using Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models;
 namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Serialization;
 
 [Serializable]
-internal class PaYamlSerializationException : Exception
+public class PaYamlSerializationException : Exception
 {
     public PaYamlSerializationException(string reason, PaYamlLocation? eventStart)
         : this(reason, eventStart, null)

--- a/src/Persistence/PaYaml/Serialization/YamlConverterOfT.cs
+++ b/src/Persistence/PaYaml/Serialization/YamlConverterOfT.cs
@@ -24,11 +24,11 @@ public abstract class YamlConverter<T> : IYamlTypeConverter
     public PaSerializationContext SerializationContext { get; }
 
     /// <summary>
-    /// The default implementation returns true when <paramref name="typeToConvert"/> equals typeof(<typeparamref name="T"/>).
+    /// The default implementation returns true when <paramref name="type"/> equals typeof(<typeparamref name="T"/>).
     /// </summary>
-    public virtual bool Accepts(Type typeToConvert)
+    public virtual bool Accepts(Type type)
     {
-        return typeToConvert == Type;
+        return type == Type;
     }
 
     public abstract T ReadYaml(IParser parser, Type typeToConvert);

--- a/src/Persistence/Templates/IControlFactory.cs
+++ b/src/Persistence/Templates/IControlFactory.cs
@@ -6,6 +6,7 @@ using Microsoft.PowerPlatform.PowerApps.Persistence.Models;
 
 namespace Microsoft.PowerPlatform.PowerApps.Persistence.Templates;
 
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "CA1716:Identifiers should not match keywords", Justification = "REVIEW: Consider fixing by renaming parameters or update this Justification.")]
 public interface IControlFactory
 {
     Control Create(string name, string template, string? componentDefinitionName = null, string? componentLibraryUniqueName = null, string? variant = null, ControlPropertiesCollection? properties = null, IList<Control>? children = null);

--- a/src/Persistence/Yaml/AppConverter.cs
+++ b/src/Persistence/Yaml/AppConverter.cs
@@ -8,7 +8,7 @@ using YamlDotNet.Serialization.Utilities;
 
 namespace Microsoft.PowerPlatform.PowerApps.Persistence.Yaml;
 
-internal class AppConverter : ControlConverter
+internal sealed class AppConverter : ControlConverter
 {
     public AppConverter(IControlFactory controlFactory) : base(controlFactory)
     {

--- a/src/Persistence/Yaml/ComponentConverter.cs
+++ b/src/Persistence/Yaml/ComponentConverter.cs
@@ -10,7 +10,7 @@ using YamlDotNet.Serialization.Utilities;
 
 namespace Microsoft.PowerPlatform.PowerApps.Persistence.Yaml;
 
-internal class ComponentConverter : ControlConverter
+internal sealed class ComponentConverter : ControlConverter
 {
     public ComponentConverter(IControlFactory controlFactory) : base(controlFactory)
     {

--- a/src/Persistence/Yaml/ControlCollectionConverter.cs
+++ b/src/Persistence/Yaml/ControlCollectionConverter.cs
@@ -1,7 +1,6 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.PowerPlatform.PowerApps.Persistence.Extensions;
 using Microsoft.PowerPlatform.PowerApps.Persistence.Models;
 using YamlDotNet.Core;
@@ -11,14 +10,13 @@ using YamlDotNet.Serialization.Utilities;
 
 namespace Microsoft.PowerPlatform.PowerApps.Persistence.Yaml;
 
-internal class ControlCollectionConverter : IYamlTypeConverter
+internal sealed class ControlCollectionConverter : IYamlTypeConverter
 {
     public ControlCollectionConverter()
     {
     }
 
-    [SuppressMessage("Performance", "CA1805:Do not initialize unnecessarily", Justification = "Explicitly setting to false for clarity")]
-    public bool IsTextFirst { get; set; } = false;
+    public bool IsTextFirst { get; set; }
 
     public IValueDeserializer? ValueDeserializer { get; set; }
 

--- a/src/Persistence/Yaml/ControlPropertiesCollectionConverter.cs
+++ b/src/Persistence/Yaml/ControlPropertiesCollectionConverter.cs
@@ -74,7 +74,7 @@ public class ControlPropertiesCollectionConverter : IYamlTypeConverter
                 }
 
                 // String values should be quoted and anything else is formula starting with '='.
-                if (1 < propertyValue.Length && propertyValue.StartsWith('\"') && propertyValue.EndsWith('\"') && !propertyValue.StartsWith("\"="))
+                if (1 < propertyValue.Length && propertyValue.StartsWith('\"') && propertyValue.EndsWith('\"') && !propertyValue.StartsWithOrdinal("\"="))
                 {
                     propertyValue = propertyValue[1..(propertyValue.Length - 1)];
                 }

--- a/src/Persistence/Yaml/ControlPropertyConverter.cs
+++ b/src/Persistence/Yaml/ControlPropertyConverter.cs
@@ -9,7 +9,7 @@ using Microsoft.PowerPlatform.PowerApps.Persistence.Extensions;
 
 namespace Microsoft.PowerPlatform.PowerApps.Persistence.Yaml;
 
-internal class ControlPropertyConverter : IYamlTypeConverter
+internal sealed class ControlPropertyConverter : IYamlTypeConverter
 {
     public bool Accepts(Type type)
     {

--- a/src/Persistence/Yaml/ControlTypeDiscriminator.cs
+++ b/src/Persistence/Yaml/ControlTypeDiscriminator.cs
@@ -9,7 +9,7 @@ using YamlDotNet.Serialization.BufferedDeserialization.TypeDiscriminators;
 
 namespace Microsoft.PowerPlatform.PowerApps.Persistence.Yaml;
 
-internal class ControlTypeDiscriminator : ITypeDiscriminator
+internal sealed class ControlTypeDiscriminator : ITypeDiscriminator
 {
     private readonly IControlTemplateStore _controlTemplateStore;
 

--- a/src/Persistence/Yaml/ControlTypeInspector.cs
+++ b/src/Persistence/Yaml/ControlTypeInspector.cs
@@ -7,7 +7,7 @@ using YamlDotNet.Serialization;
 
 namespace Microsoft.PowerPlatform.PowerApps.Persistence.Yaml;
 
-internal class ControlTypeInspector : ITypeInspector
+internal sealed class ControlTypeInspector : ITypeInspector
 {
     private readonly ITypeInspector _innerTypeInspector;
     private readonly IControlTemplateStore _controlTemplateStore;
@@ -22,7 +22,7 @@ internal class ControlTypeInspector : ITypeInspector
     {
         var properties = _innerTypeInspector.GetProperties(type, container);
         if (_controlTemplateStore.Contains(type))
-            return properties.Where(p => !p.Name.Equals(YamlFields.Control));
+            return properties.Where(p => !p.Name.Equals(YamlFields.Control, StringComparison.Ordinal));
 
         return properties;
     }
@@ -61,7 +61,7 @@ internal class ControlTypeInspector : ITypeInspector
             // for example
             // App:
             // Name: My Custom Control
-            if (name.Equals(templateName))
+            if (name.Equals(templateName, StringComparison.Ordinal))
                 return new EmptyPropertyDescriptor(name);
         }
 

--- a/src/Persistence/Yaml/FirstClassControlsEmitter.cs
+++ b/src/Persistence/Yaml/FirstClassControlsEmitter.cs
@@ -10,7 +10,7 @@ using YamlDotNet.Serialization.EventEmitters;
 
 namespace Microsoft.PowerPlatform.PowerApps.Persistence.Yaml;
 
-internal class FirstClassControlsEmitter : ChainedEventEmitter
+internal sealed class FirstClassControlsEmitter : ChainedEventEmitter
 {
     private readonly IControlTemplateStore _controlTemplateStore;
     private readonly IReadOnlySet<string> _shortNameTypes = new HashSet<string> { "App", "Host", "Screen" };

--- a/src/Persistence/Yaml/NamedObjectEmitter.cs
+++ b/src/Persistence/Yaml/NamedObjectEmitter.cs
@@ -14,7 +14,7 @@ namespace Microsoft.PowerPlatform.PowerApps.Persistence.Yaml;
 ///    Property1: Value1
 ///    Property2: Value2
 /// </summary>
-internal class NamedObjectEmitter : ChainedEventEmitter
+internal sealed class NamedObjectEmitter : ChainedEventEmitter
 {
     private readonly Stack<bool> _isNamedObject = new();
     private bool _isName;

--- a/src/Persistence/Yaml/NamedObjectTypeInspector.cs
+++ b/src/Persistence/Yaml/NamedObjectTypeInspector.cs
@@ -5,7 +5,7 @@ using YamlDotNet.Serialization;
 
 namespace Microsoft.PowerPlatform.PowerApps.Persistence.Yaml;
 
-internal class NamedObjectTypeInspector : ITypeInspector
+internal sealed class NamedObjectTypeInspector : ITypeInspector
 {
     private readonly ITypeInspector _innerTypeInspector;
 
@@ -18,7 +18,7 @@ internal class NamedObjectTypeInspector : ITypeInspector
     {
         var properties = _innerTypeInspector.GetProperties(type, container);
         if (typeof(INamedObject).IsAssignableFrom(type))
-            return properties.Where(p => !p.Name.Equals(nameof(INamedObject.Name)));
+            return properties.Where(p => !p.Name.Equals(nameof(INamedObject.Name), StringComparison.Ordinal));
 
         return properties;
     }


### PR DESCRIPTION

## Problem

Not all of the code analysys rules are enabled for this repo.

## Solution

Enabled all the known rule categories and address and rule violations.

## Changes

- Enabled all known rule categories to be 'warning'. Security rules set to 'error'.
- Fixed rule violations in Persistence projects
- Disabled these categories in PAModel, PAModelTests, PASopa as we aren't desiring to make any changes in these APIs.
- Remove unnecessary explicit rule configurations to simplify .editorconfig

## Validation

No semantic changes. Existing tests are sufficient.