### PR TITLE
CLI scaffolding for YAMLValidator

### DIFF
--- a/src/PASopa.sln
+++ b/src/PASopa.sln
@@ -20,6 +20,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.PowerPlatform.Pow
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Persistence.Tests", "Persistence.Tests\Persistence.Tests.csproj", "{8AB1C901-FE5E-44BF-AA21-B8F20A9D7CDD}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "YAMLValidator", "YAMLValidator\YAMLValidator.csproj", "{F0AD11CE-E634-4945-A6B1-7866CDE0059C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -46,6 +48,10 @@ Global
 		{8AB1C901-FE5E-44BF-AA21-B8F20A9D7CDD}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{8AB1C901-FE5E-44BF-AA21-B8F20A9D7CDD}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{8AB1C901-FE5E-44BF-AA21-B8F20A9D7CDD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F0AD11CE-E634-4945-A6B1-7866CDE0059C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F0AD11CE-E634-4945-A6B1-7866CDE0059C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F0AD11CE-E634-4945-A6B1-7866CDE0059C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F0AD11CE-E634-4945-A6B1-7866CDE0059C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/YAMLValidator/InputProcessor.cs
+++ b/src/YAMLValidator/InputProcessor.cs
@@ -1,0 +1,99 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+
+//using System.CommandLine;
+//using System.IO;
+
+using System.CommandLine;
+
+namespace YAMLValidator;
+internal sealed class InputProcessor
+{
+
+    public static RootCommand GetRootCommand()
+    {
+
+        const string FileTypeName = "file";
+        const string FolderTypeName = "folder";
+        const string yamlFileExtension = ".yaml";
+
+        // windows handles edge case where file and folder have same name
+        var pathOption = new Option<string>(
+            name: "--path",
+            description: "The path to the input yaml file or directory of yaml files"
+        )
+        { IsRequired = true };
+
+        pathOption.AddValidator(result =>
+        {
+            var inputFilePath = result.GetValueForOption(pathOption);
+
+            // either file or folder must be passed
+            var pathType = string.Empty;
+            if (string.IsNullOrEmpty(inputFilePath))
+            {
+                result.ErrorMessage = "The input is invalid, input must be a filepath to a yaml file or a folder path to a folder of yaml files";
+            }
+            else if (!Directory.Exists(inputFilePath) && !File.Exists(inputFilePath))
+            {
+                result.ErrorMessage = "The input path does not exist";
+            }
+            else if (Directory.Exists(inputFilePath))
+            {
+                if (Directory.GetFiles(inputFilePath, $"*{yamlFileExtension}").Length == 0)
+                {
+                    result.ErrorMessage = "The input folder does not contain any yaml files";
+                }
+            }
+            else if (File.Exists(inputFilePath))
+            {
+                if (Path.GetExtension(inputFilePath) != yamlFileExtension)
+                {
+                    result.ErrorMessage = "The input file must be a yaml file";
+                }
+            }
+        });
+
+        var schemaOption = new Option<string>(
+            name: "--schema",
+            description: "The path to the schema yaml file",
+            getDefaultValue: () => @"..\schemas\pa-yaml\v3.0\pa.schema.yaml"
+        );
+
+        schemaOption.AddValidator(result =>
+        {
+            var schemaPath = result.GetValueForOption(schemaOption);
+            if (string.IsNullOrEmpty(schemaPath))
+            {
+                result.ErrorMessage = "Schema option selected, but no schema was provided";
+            }
+        });
+
+        // define root
+        var rootCommand = new RootCommand("YAML validator cli-tool");
+
+        // commands
+        // validate
+        var validateCommand = new Command("validate", "Validate the input yaml file")
+        {
+            pathOption,
+            schemaOption
+        };
+
+        validateCommand.SetHandler((pathOptionVal, schemaOptionVal) =>
+        {
+            // validation has completed, we either have a file or folder
+            var fileType = File.Exists(pathOptionVal) ? FileTypeName : FolderTypeName;
+            Console.WriteLine($@"Validating
+                                 Path: {pathOptionVal}
+                                 Filetype: {fileType}
+                                 Schema: {schemaOptionVal}");
+        }, pathOption, schemaOption);
+
+        rootCommand.AddCommand(validateCommand);
+
+        return rootCommand;
+
+    }
+}

--- a/src/YAMLValidator/Program.cs
+++ b/src/YAMLValidator/Program.cs
@@ -1,0 +1,15 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.CommandLine;
+
+namespace YAMLValidator;
+
+internal sealed class Program
+{
+    private static void Main(String[] args)
+    {
+        var inputProcessor = InputProcessor.GetRootCommand();
+        inputProcessor.Invoke(args);
+    }
+}

--- a/src/YAMLValidator/YAMLValidator.csproj
+++ b/src/YAMLValidator/YAMLValidator.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="$(MicrosoftExtensionsLoggingVersion)" />
+    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Persistence\Microsoft.PowerPlatform.PowerApps.Persistence.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION


## Problem

N/A

## Solution

N/A

## Changes

- Adds the initial CLI scaffolding and verification for the YAML validator, which for now, only verifies file extemsions and validates the files and directories exists.
- The added command includes the ```validate``` CLI command, flags include:
    - required ```--path``` a path to a .yaml or folder of .yaml files
    - optional ```--schema``` a path to a local schema .json file, or a default one if it is not passed in.
- 

## Testing
- For now only manual tests were done to verify input filepaths, these tests included
    1. No parameters passed to cli
    2. Validate command without parameters
    3. Validate command with an invalid and valid file path
    4. Validate command with an invalid and valid folder path
    5. Path option input validation to check at least 1 .yaml file exists in a folder
    6. Path option input validation to check Verification that a file has .yaml extension
    7. Check that schema path option input exists in the file system and is a .json file.
    8. Also note, windows wont allow a file and folders with the same name to exist in a path, so this case was ignored
- Perhaps later, tests for this project can be made an run in a new project called YAMLValidator.Tests


