### PR TITLE
Skip ZIndex from being serialized.

### DIFF
--- a/src/Persistence.Tests/Yaml/ValidSerializerTests.cs
+++ b/src/Persistence.Tests/Yaml/ValidSerializerTests.cs
@@ -181,18 +181,56 @@ public class ValidSerializerTests : TestBase
                             properties: new()
                             {
                                 { "TemplateFill", "RGBA(0, 0, 0, 0)" },
+                                { "ZIndex", "1" },
                             }
                         ),
                         ControlFactory.Create("button12", template: "button",
                             properties: new()
                             {
                                 { "Fill", "RGBA(0, 0, 0, 0)" },
+                                { "ZIndex", "1" },
                             }
                         )
                     }
                 )
             }
         );
+
+        var serializer = CreateSerializer(isControlIdentifiers);
+
+        var sut = serializer.SerializeControl(graph).NormalizeNewlines();
+        var expectedYaml = File.ReadAllText(GetTestFilePath(expectedPath, isControlIdentifiers)).NormalizeNewlines();
+        sut.Should().Be(expectedYaml);
+    }
+
+    [TestMethod]
+    [DataRow(@"_TestData/ValidYaml{0}/ZIndexOrdering/with-addpropertiestoparents-control.pa.yaml", true)]
+    [DataRow(@"_TestData/ValidYaml{0}/ZIndexOrdering/with-addpropertiestoparents-control.pa.yaml", false)]
+    public void Serialize_Should_FlattenGalleryTemplateWithoutZIndex(string expectedPath, bool isControlIdentifiers)
+    {
+        var graph = ControlFactory.Create("Gallery1", template: "gallery",
+                   properties: new()
+                    {
+                        { "Items", "Accounts" },
+                    },
+                    children: new List<Control>()
+                    {
+                        ControlFactory.Create("GalleryTemplate1", template: "galleryTemplate",
+                            properties: new()
+                            {
+                                { "TemplateFill", "RGBA(0, 0, 0, 0)" },
+                                { "ZIndex", "1" },
+                            }
+                        ),
+                        ControlFactory.Create("Button1", template: "button",
+                            properties: new()
+                            {
+                                { "Fill", "RGBA(0, 0, 0, 0)" },
+                                { "ZIndex", "1" },
+                            }
+                        )
+                    }
+               );
 
         var serializer = CreateSerializer(isControlIdentifiers);
 

--- a/src/Persistence.Tests/_TestData/ValidYaml-CI/ZIndexOrdering/with-addpropertiestoparents-control.pa.yaml
+++ b/src/Persistence.Tests/_TestData/ValidYaml-CI/ZIndexOrdering/with-addpropertiestoparents-control.pa.yaml
@@ -1,0 +1,10 @@
+Gallery1:
+  Control: Gallery
+  Properties:
+    Items: =Accounts
+    TemplateFill: =RGBA(0, 0, 0, 0)
+  Children:
+  - Button1:
+      Control: Button
+      Properties:
+        Fill: =RGBA(0, 0, 0, 0)

--- a/src/Persistence.Tests/_TestData/ValidYaml/ZIndexOrdering/with-addpropertiestoparents-control.pa.yaml
+++ b/src/Persistence.Tests/_TestData/ValidYaml/ZIndexOrdering/with-addpropertiestoparents-control.pa.yaml
@@ -1,0 +1,10 @@
+Control: Gallery
+Name: Gallery1
+Properties:
+  Items: =Accounts
+  TemplateFill: =RGBA(0, 0, 0, 0)
+Children:
+- Control: Button
+  Name: Button1
+  Properties:
+    Fill: =RGBA(0, 0, 0, 0)

--- a/src/Persistence/Yaml/ControlFormatter.cs
+++ b/src/Persistence/Yaml/ControlFormatter.cs
@@ -20,7 +20,7 @@ public static class ControlFormatter
         _ = control ?? throw new ArgumentNullException(nameof(control));
 
         var childrenToRemove = (control.Children ?? Enumerable.Empty<Control>()).Where(c => c.Template.AddPropertiesToParent).ToList();
-        var propertiesToMerge = childrenToRemove.SelectMany(c => c.Properties).ToList();
+        var propertiesToMerge = childrenToRemove.SelectMany(c => c.Properties.Where(p => p.Key != PropertyNames.ZIndex)).ToList();
 
         var isGroupContainer = control.Template.Name == BuiltInTemplates.GroupContainer.Name;
 


### PR DESCRIPTION
If this is related to an issue open in GitHub, please link it to this ticket and put the URL here.

## Problem

What is the issue we are attempting to solve?
Currently when we vie code for gallery, the ZIndex is being serialized at the parent level. Changes here are the skip the ZIndex

## Solution

Add a check to skip Zindex

## Changes

- Log what was changed
- Log what was changed
- Log what was changed

## Validation

- How did you verify that this issue is truly fixed?
