### PR TITLE
Fix broken build, and inner dev-loop configurations

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -120,7 +120,7 @@ dotnet_code_quality_unused_parameters = all:suggestion
 [*.cs]
 csharp_indent_labels = one_less_than_current
 csharp_using_directive_placement = outside_namespace:error
-csharp_prefer_simple_using_statement = true:error
+csharp_prefer_simple_using_statement = true:suggestion
 csharp_prefer_braces = true:silent
 csharp_style_namespace_declarations = file_scoped:error
 csharp_style_prefer_method_group_conversion = true:silent
@@ -188,7 +188,7 @@ dotnet_analyzer_diagnostic.category-Naming.severity           = warning
 dotnet_analyzer_diagnostic.category-Performance.severity      = warning
 dotnet_analyzer_diagnostic.category-Reliability.severity      = warning
 dotnet_analyzer_diagnostic.category-Security.severity         = error
-dotnet_analyzer_diagnostic.category-Style.severity            = error
+dotnet_analyzer_diagnostic.category-Style.severity            = warning
 dotnet_analyzer_diagnostic.category-Usage.severity            = warning
 
 # *********************************
@@ -200,9 +200,10 @@ dotnet_analyzer_diagnostic.category-Usage.severity            = warning
 
 dotnet_diagnostic.IDE0003.severity = error      # this and Me preferences
 dotnet_diagnostic.IDE0007.severity = error      # Use 'var' instead of explicit type
-dotnet_diagnostic.IDE0005.severity = error      # Remove unnecessary using directives
+dotnet_diagnostic.IDE0005.severity = warning    # Remove unnecessary using directives
 dotnet_diagnostic.IDE0010.severity = none       # Add missing cases to switch statement
 dotnet_diagnostic.IDE0011.severity = none       # Add braces
+dotnet_diagnostic.IDE0018.severity = suggestion # Inline variable declaration (net8.0 doesn't respect the severity set for csharp_style_inlined_variable_declaration)
 dotnet_diagnostic.IDE0028.severity = none       # Use collection initializers or expressions
 dotnet_diagnostic.IDE0042.severity = none       # Deconstruct variable declaration
 dotnet_diagnostic.IDE0043.severity = warning    # Format string contains invalid placeholder
@@ -226,9 +227,9 @@ dotnet_diagnostic.IDE0130.severity = none       # Namespace does not match folde
 dotnet_diagnostic.IDE0161.severity = error      # Namespace declaration preferences
 dotnet_diagnostic.IDE0210.severity = none       # Convert to top-level statements
 dotnet_diagnostic.IDE0290.severity = suggestion # Use primary constructor
-dotnet_diagnostic.IDE0300.severity = suggestion # Collection initialization can be simplified
-dotnet_diagnostic.IDE0301.severity = suggestion # Collection initialization can be simplified
-dotnet_diagnostic.IDE0305.severity = suggestion # Collection initialization can be simplified
+dotnet_diagnostic.IDE0300.severity = suggestion # Use collection expression for array
+dotnet_diagnostic.IDE0301.severity = suggestion # Use collection expression for empty
+dotnet_diagnostic.IDE0305.severity = suggestion # Use collection expression for fluent
 dotnet_diagnostic.IDE1006.severity = none       # These words must begin with upper case characters
 
 

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,7 +10,15 @@
   "yaml.validate": true,
   "yaml.schemas": {
     // This schema registration is the 'default' for any *.pa.yaml files
-    "https://raw.githubusercontent.com/microsoft/PowerApps-Tooling/master/docs/pa.yaml-schema.json": "*.pa.yaml",
+    "https://raw.githubusercontent.com/microsoft/PowerApps-Tooling/master/docs/pa.yaml-schema.json": [
+      "*.pa.yaml",
+      // Need to exclude these files which use the PaYamlV3 schema
+      "!src/schemas-tests/pa-yaml/v3.0/**/*.pa.yaml"
+    ],
+    // This schema registration ensures development of *.pa.yaml files which should map to PaYamlV3 will work
+    "src/schemas/pa-yaml/v3.0/pa.schema.yaml": [
+      "src/schemas-tests/pa-yaml/v3.0/**/*.pa.yaml"
+    ],
     // *.schema.yaml files should use JSON schema:
     "http://json-schema.org/draft-07/schema#": "*.schema.yaml"
   }

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -7,16 +7,26 @@
         <GenerateDocumentationFile>True</GenerateDocumentationFile>
         <NoWarn>1591</NoWarn>
         <ChecksumAlgorithm>SHA256</ChecksumAlgorithm>
-    </PropertyGroup>
-
-    <PropertyGroup>
-        <!-- Without this, some code styling rules only execute in VS IDE, sometimes, only when the file is open -->
-        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
-        <EnableNETAnalyzers>true</EnableNETAnalyzers>        
-        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-        <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
         <!-- https://github.com/dotnet/core/blob/main/release-notes/8.0/known-issues.md#802xx-sdk-is-not-compatible-with-178-for-some-scenarios -->
         <BuildWithNetFrameworkHostedCompiler>true</BuildWithNetFrameworkHostedCompiler>
+    </PropertyGroup>
+
+    <PropertyGroup Label="Code Analysis config">
+        <!-- Without this, some code styling rules only execute in VS IDE, sometimes, only when the file is open -->
+        <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+        <EnableNETAnalyzers>true</EnableNETAnalyzers>
+        <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+        <CodeAnalysisTreatWarningsAsErrors>true</CodeAnalysisTreatWarningsAsErrors>
+    </PropertyGroup>
+
+    <!--
+    When building in VS IDE, we don't want to treat warnings as errors, because they randomize developer progress.
+    Warnings will be treated as errors at command line and in build pipelines
+    -->
+  <PropertyGroup Label="Code Analysis config for VS IDE"
+                 Condition="'$(BuildingInsideVisualStudio)' == 'true'">
+        <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+        <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
     </PropertyGroup>
 
     <ItemGroup>

--- a/src/PASopa.sln
+++ b/src/PASopa.sln
@@ -20,6 +20,12 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Microsoft.PowerPlatform.Pow
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Persistence.Tests", "Persistence.Tests\Persistence.Tests.csproj", "{8AB1C901-FE5E-44BF-AA21-B8F20A9D7CDD}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{7361DB16-D534-4E0E-8597-BE22317DEF47}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
+		Versions.props = Versions.props
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -53,6 +59,7 @@ Global
 	GlobalSection(NestedProjects) = preSolution
 		{8AD94CC0-7330-4880-A8E0-177B37CDB27B} = {4993E606-484B-46D9-892E-7AE9CE8D4423}
 		{8AB1C901-FE5E-44BF-AA21-B8F20A9D7CDD} = {4993E606-484B-46D9-892E-7AE9CE8D4423}
+		{7361DB16-D534-4E0E-8597-BE22317DEF47} = {794D8C68-BF6F-49C8-BCA5-AA52D8F45EF4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C936F8B1-DE7A-4401-95D5-5E199210F960}

--- a/src/Persistence.Tests/.editorconfig
+++ b/src/Persistence.Tests/.editorconfig
@@ -1,4 +1,4 @@
-﻿[*.cs]
+[*.cs]
 
 dotnet_diagnostic.CA1861.severity = silent # Prefer 'static readonly' fields over constant array arguments if the called method is called repeatedly and is not mutating the passed array
-dotnet_diagnostic.CA1859.severity = silent # Change return type of method
+dotnet_diagnostic.CA1859.severity = silent # Use concrete types when possible for improved performance


### PR DESCRIPTION
This PR re-fixes issues in the inner dev loop which I'd previously fixed but have been broken again. All of these changes have been fixed at one point, hopefully it'll stick this time.

- Turned off TreatWarningsAsErrors in VS IDE to speed up inner-dev-loop.
   building locally in VS IDE causes warnings to be treated as Errors. This negatively impacts the inner dev loop experience and causes slower iterative development.
- fix settings.json so PaYamlV3 files use the correct schema file
  *.pa.yaml files under the PaYamlV3 folders in the repo no longer work with the schemas as they did before.
- Turned some code analysis rules from Error to Warning to improve inner dev-loop
