### PR TITLE
Clean yaml validator false positive output

### DIFF
--- a/src/YamlValidator/ValidatorResults.cs
+++ b/src/YamlValidator/ValidatorResults.cs
@@ -12,11 +12,11 @@ public class ValidatorResults
     public ValidatorResults(bool schemaValid, IReadOnlyList<ValidatorError> traversalResults)
     {
         SchemaValid = schemaValid;
-        TraversalResults = filterErrors(traversalResults);
+        TraversalResults = FilterErrors(traversalResults);
     }
 
     //  This will filter out the false positives that are not relevant to the error output, when the validation is false
-    private ReadOnlyCollection<ValidatorError> filterErrors(IReadOnlyList<ValidatorError> traversalResults)
+    private ReadOnlyCollection<ValidatorError> FilterErrors(IReadOnlyList<ValidatorError> traversalResults)
     {
         var maxSchemaArraySuffixSize = 0;
         var maxSchemaObjectSuffixSize = 0;

--- a/src/YamlValidator/ValidatorResults.cs
+++ b/src/YamlValidator/ValidatorResults.cs
@@ -15,31 +15,24 @@ public class ValidatorResults
         TraversalResults = filterErrors(traversalResults);
     }
 
-    /* *
-     * Fix: this will filter out the false positives that are not relevant to the error output, when the validation is false
-     * Filters the errors to only include the errors that are relevant to the schema.
-     * For all instance paths in the schema with paths oneOf/0 and oneOf/1, we find the max suffix size and only keep the errors 
-     * from that OneOf path with the max suffix size.
-     * Why? since errors are propogated up the schema validation tree, the errors at the leaf nodes are the 
-     * most relevant but can have false positives due to the OneOf statement in the schema.
-     * */
+    //  This will filter out the false positives that are not relevant to the error output, when the validation is false
     private ReadOnlyCollection<ValidatorError> filterErrors(IReadOnlyList<ValidatorError> traversalResults)
     {
         var maxSchemaArraySuffixSize = 0;
         var maxSchemaObjectSuffixSize = 0;
-        var arrayTypeFile = "/oneOf/1";
-        var objectTypeFile = "/oneOf/0";
+        var arrayTypeSchemaPath = "/oneOf/1";
+        var objectTypeSchemaPath = "/oneOf/0";
         foreach (var err in traversalResults)
         {
             var errSchemaPath = err.SchemaPath;
-            if (!errSchemaPath.StartsWith(arrayTypeFile, StringComparison.Ordinal) &&
-                !err.SchemaPath.StartsWith(objectTypeFile, StringComparison.Ordinal))
+            if (!errSchemaPath.StartsWith(arrayTypeSchemaPath, StringComparison.Ordinal) &&
+                !err.SchemaPath.StartsWith(objectTypeSchemaPath, StringComparison.Ordinal))
             {
                 continue;
             }
 
-            var suffixLength = errSchemaPath.Length - arrayTypeFile.Length;
-            if (errSchemaPath.StartsWith(arrayTypeFile, StringComparison.Ordinal))
+            var suffixLength = errSchemaPath.Length - arrayTypeSchemaPath.Length;
+            if (errSchemaPath.StartsWith(arrayTypeSchemaPath, StringComparison.Ordinal))
             {
                 maxSchemaArraySuffixSize = Math.Max(maxSchemaArraySuffixSize, suffixLength);
             }
@@ -52,14 +45,14 @@ public class ValidatorResults
         foreach (var err in traversalResults)
         {
             var errSchemaPath = err.SchemaPath;
-            if (!errSchemaPath.StartsWith(arrayTypeFile, StringComparison.Ordinal) &&
-                !err.SchemaPath.StartsWith(objectTypeFile, StringComparison.Ordinal))
+            if (!errSchemaPath.StartsWith(arrayTypeSchemaPath, StringComparison.Ordinal) &&
+                !err.SchemaPath.StartsWith(objectTypeSchemaPath, StringComparison.Ordinal))
             {
                 filteredErrors.Add(err);
                 continue;
             }
 
-            if (errSchemaPath.StartsWith(arrayTypeFile, StringComparison.Ordinal))
+            if (errSchemaPath.StartsWith(arrayTypeSchemaPath, StringComparison.Ordinal))
             {
                 if (maxSchemaArraySuffixSize >= maxSchemaObjectSuffixSize)
                 {

--- a/src/YamlValidator/ValidatorResults.cs
+++ b/src/YamlValidator/ValidatorResults.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.ObjectModel;
+
 namespace Microsoft.PowerPlatform.PowerApps.Persistence.YamlValidator;
 public class ValidatorResults
 {
@@ -10,6 +12,70 @@ public class ValidatorResults
     public ValidatorResults(bool schemaValid, IReadOnlyList<ValidatorError> traversalResults)
     {
         SchemaValid = schemaValid;
-        TraversalResults = traversalResults;
+        TraversalResults = filterErrors(traversalResults);
+    }
+
+    /* *
+     * Fix: this will filter out the false positives that are not relevant to the error output, when the validation is false
+     * Filters the errors to only include the errors that are relevant to the schema.
+     * For all instance paths in the schema with paths oneOf/0 and oneOf/1, we find the max suffix size and only keep the errors 
+     * from that OneOf path with the max suffix size.
+     * Why? since errors are propogated up the schema validation tree, the errors at the leaf nodes are the 
+     * most relevant but can have false positives due to the OneOf statement in the schema.
+     * */
+    private ReadOnlyCollection<ValidatorError> filterErrors(IReadOnlyList<ValidatorError> traversalResults)
+    {
+        var maxSchemaArraySuffixSize = 0;
+        var maxSchemaObjectSuffixSize = 0;
+        var arrayTypeFile = "/oneOf/1";
+        var objectTypeFile = "/oneOf/0";
+        foreach (var err in traversalResults)
+        {
+            var errSchemaPath = err.SchemaPath;
+            if (!errSchemaPath.StartsWith(arrayTypeFile, StringComparison.Ordinal) &&
+                !err.SchemaPath.StartsWith(objectTypeFile, StringComparison.Ordinal))
+            {
+                continue;
+            }
+
+            var suffixLength = errSchemaPath.Length - arrayTypeFile.Length;
+            if (errSchemaPath.StartsWith(arrayTypeFile, StringComparison.Ordinal))
+            {
+                maxSchemaArraySuffixSize = Math.Max(maxSchemaArraySuffixSize, suffixLength);
+            }
+            else
+            {
+                maxSchemaObjectSuffixSize = Math.Max(maxSchemaObjectSuffixSize, suffixLength);
+            }
+        }
+        var filteredErrors = new List<ValidatorError>();
+        foreach (var err in traversalResults)
+        {
+            var errSchemaPath = err.SchemaPath;
+            if (!errSchemaPath.StartsWith(arrayTypeFile, StringComparison.Ordinal) &&
+                !err.SchemaPath.StartsWith(objectTypeFile, StringComparison.Ordinal))
+            {
+                filteredErrors.Add(err);
+                continue;
+            }
+
+            if (errSchemaPath.StartsWith(arrayTypeFile, StringComparison.Ordinal))
+            {
+                if (maxSchemaArraySuffixSize >= maxSchemaObjectSuffixSize)
+                {
+                    filteredErrors.Add(err);
+                }
+            }
+            else
+            {
+                if (maxSchemaObjectSuffixSize >= maxSchemaArraySuffixSize)
+                {
+                    filteredErrors.Add(err);
+                }
+            }
+
+        }
+
+        return filteredErrors.AsReadOnly();
     }
 }


### PR DESCRIPTION
## Problem

- In the current validation output there is an edge case with returning output on an Invalid Schema.
- The schema structure requires that at the root of the yaml we either have a single control or an array of controls (using a OneOf json-schema statement)
![image](https://github.com/microsoft/PowerApps-Tooling/assets/170759993/e55c1ca4-c585-40b9-b713-948f151c3929)
- In a valid schema, a single evaluation path being true (object or array of objects) will make the entire schema true
- In an invalid schema, both evaluation paths will be false. Suppose we wanted to trace an error; we would have to go down both evaluation paths in the evaluation tree (one of which would always evaluate to false even if the schema was valid). 
- This additional useless information is output on the console to the user and is confusing/uninformative. This pr removes the evaluation path which contains useless information.

## Solution

- Among the schema evaluation path which require we have a single control object or array of control object; we find which evaluation path has the longest suffix and filter out the rest of the evaluation paths with a smaller length suffix. 

## Validation

- Only local test with examples I made. Perhaps we can add unit tests on the actual errors of the schema, as opposed to simply checking if the entire schema evaluated true or false
