### PR TITLE
Return Formulas.Tools to netstandard2.0

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -39,7 +39,6 @@
         <Using Include="System" />
         <Using Include="System.Collections.Generic" />
         <Using Include="System.Diagnostics" />
-        <Using Include="Microsoft.Extensions.DependencyInjection" />
     </ItemGroup>
 
     <!-- If not otherwise specified, the project is building for Debug -->

--- a/src/PAModel/Checksum/ChecksumMaker.cs
+++ b/src/PAModel/Checksum/ChecksumMaker.cs
@@ -225,6 +225,7 @@ public class ChecksumMaker
     // Formula whitespace can differ between platforms, and leading whitespace
     // is affected by writing to .pa format. Normalize so checksums are
     // platform independent
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0056:Use index operator", Justification = "Not available in netstandard2.0")]
     internal static string NormFormulaWhitespace(string s)
     {
         var sb = new StringBuilder();

--- a/src/PAModel/Checksum/ChecksumMaker.cs
+++ b/src/PAModel/Checksum/ChecksumMaker.cs
@@ -247,7 +247,7 @@ public class ChecksumMaker
             }
         }
         // Don't include trailing whitespace
-        while ((sb.Length > 1) && sb[^1] == ' ') { sb.Length--; }
+        while ((sb.Length > 1) && sb[sb.Length - 1] == ' ') { sb.Length--; }
 
         return sb.ToString();
     }

--- a/src/PAModel/IsExternalInit.cs
+++ b/src/PAModel/IsExternalInit.cs
@@ -1,0 +1,25 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+#if NETFRAMEWORK || NETSTANDARD2_0
+#pragma warning disable
+
+using System.ComponentModel;
+
+namespace System.Runtime.CompilerServices;
+
+// C# 9 init property setters and record types do not quite function out-of-the-box
+// for net4.8, but do so long as an "System.Runtime.CompilerServices.IsExternalInit"
+// type merely exists.
+[EditorBrowsable(EditorBrowsableState.Never)]
+#if TFMADAPTERS_PUBLIC
+public
+#else
+internal
+#endif
+static class IsExternalInit
+{
+}
+
+#pragma warning restore
+#endif

--- a/src/PAModel/Microsoft.PowerPlatform.Formulas.Tools.csproj
+++ b/src/PAModel/Microsoft.PowerPlatform.Formulas.Tools.csproj
@@ -1,6 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>12</LangVersion>
     <AssemblyName>Microsoft.PowerPlatform.Formulas.Tools</AssemblyName>
     <RootNamespace>Microsoft.PowerPlatform.Formulas.Tools</RootNamespace>
   </PropertyGroup>
@@ -48,9 +50,5 @@
     <PackageReference Include="System.Text.Json" Version="[6.0,)" />
     <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
     <PackageReference Include="YamlDotNet" Version="$(YamlDotNetVersion)" />
-  </ItemGroup>
-    
-  <ItemGroup>
-    <ProjectReference Include="..\Persistence\Microsoft.PowerPlatform.PowerApps.Persistence.csproj" />
   </ItemGroup>
 </Project>

--- a/src/PAModel/Microsoft.PowerPlatform.Formulas.Tools.csproj
+++ b/src/PAModel/Microsoft.PowerPlatform.Formulas.Tools.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
     <LangVersion>12</LangVersion>
     <AssemblyName>Microsoft.PowerPlatform.Formulas.Tools</AssemblyName>
     <RootNamespace>Microsoft.PowerPlatform.Formulas.Tools</RootNamespace>

--- a/src/PAModel/PAConvert/Parser/CharacterUtils.cs
+++ b/src/PAModel/PAConvert/Parser/CharacterUtils.cs
@@ -119,6 +119,7 @@ internal static class CharacterUtils
         return false;
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0056:Use index operator", Justification = "Not available in netstandard2.0")]
     public static string UnEscapeName(string name, ErrorContainer errors)
     {
         if (IsIdentDelimiter(name[0]))

--- a/src/PAModel/PAConvert/Parser/CharacterUtils.cs
+++ b/src/PAModel/PAConvert/Parser/CharacterUtils.cs
@@ -123,7 +123,7 @@ internal static class CharacterUtils
     {
         if (IsIdentDelimiter(name[0]))
         {
-            if (!IsIdentDelimiter(name[^1]))
+            if (!IsIdentDelimiter(name[name.Length - 1]))
             {
                 // Must match
                 errors.ParseError(default, $"Unmatched escape delimeter in {name}");

--- a/src/PAModel/PAConvert/Yaml/YamlLexer.cs
+++ b/src/PAModel/PAConvert/Yaml/YamlLexer.cs
@@ -473,6 +473,7 @@ internal class YamlLexer : IDisposable
 
     // https://yaml-multiline.info/
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE0056:Use index operator", Justification = "Not available in netstandard2.0")]
     private string ReadMultiline(int multilineMode)
     {
         var sb = new StringBuilder();

--- a/src/PAModel/PAConvert/Yaml/YamlLexer.cs
+++ b/src/PAModel/PAConvert/Yaml/YamlLexer.cs
@@ -513,7 +513,7 @@ internal class YamlLexer : IDisposable
         {
             while (true)
             {
-                if (sb.Length > 0 && sb[^1] == '\n')
+                if (sb.Length > 0 && sb[sb.Length - 1] == '\n')
                 {
                     sb.Length--;
                 }
@@ -521,7 +521,7 @@ internal class YamlLexer : IDisposable
                 {
                     break;
                 }
-                if (sb.Length > 0 && sb[^1] == '\r')
+                if (sb.Length > 0 && sb[sb.Length - 1] == '\r')
                 {
                     sb.Length--;
                 }

--- a/src/PAModel/Serializers/MsAppSerializer.cs
+++ b/src/PAModel/Serializers/MsAppSerializer.cs
@@ -57,10 +57,7 @@ internal static class MsAppSerializer
 
     public static CanvasDocument Load(Stream streamToMsapp, ErrorContainer errors)
     {
-        if (streamToMsapp == null)
-        {
-            throw new ArgumentNullException(nameof(streamToMsapp));
-        }
+        _ = streamToMsapp ?? throw new ArgumentNullException(nameof(streamToMsapp));
 
         // Read raw files. 
         // Apply transforms. 

--- a/src/PAModel/Serializers/MsAppSerializer.cs
+++ b/src/PAModel/Serializers/MsAppSerializer.cs
@@ -57,7 +57,10 @@ internal static class MsAppSerializer
 
     public static CanvasDocument Load(Stream streamToMsapp, ErrorContainer errors)
     {
-        ArgumentNullException.ThrowIfNull(streamToMsapp);
+        if (streamToMsapp == null)
+        {
+            throw new ArgumentNullException(nameof(streamToMsapp));
+        }
 
         // Read raw files. 
         // Apply transforms. 

--- a/src/PAModel/packages.lock.json
+++ b/src/PAModel/packages.lock.json
@@ -101,6 +101,50 @@
           "System.Runtime.CompilerServices.Unsafe": "4.5.3"
         }
       }
+    },
+    "net8.0": {
+      "Microsoft.Net.Compilers.Toolset.Framework": {
+        "type": "Direct",
+        "requested": "[4.10.0-3.24216.12, )",
+        "resolved": "4.10.0-3.24216.12",
+        "contentHash": "Y1T1ZN3cHWToRYZHhRs8xby1tMCkF23Jb//zK+Tdf4ourzwbMQ4GiTRVVFAlWvmA10iVNUyCZucAeLt5XeiDqA=="
+      },
+      "Newtonsoft.Json": {
+        "type": "Direct",
+        "requested": "[13.0.1, )",
+        "resolved": "13.0.1",
+        "contentHash": "ppPFpBcvxdsfUonNcvITKqLl3bqxWbDCZIzDWHzjpdAHRFfZe0Dw9HmA0+za13IdyrgJwpkDTDA9fHaxOrt20A=="
+      },
+      "System.Text.Encodings.Web": {
+        "type": "Direct",
+        "requested": "[6.0.0, )",
+        "resolved": "6.0.0",
+        "contentHash": "Vg8eB5Tawm1IFqj4TVK1czJX89rhFxJo9ELqc/Eiq0eXy13RK00eubyU6TJE6y+GQXjyV5gSfiewDUZjQgSE0w==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
+        }
+      },
+      "System.Text.Json": {
+        "type": "Direct",
+        "requested": "[6.0.0, )",
+        "resolved": "6.0.0",
+        "contentHash": "zaJsHfESQvJ11vbXnNlkrR46IaMULk/gHxYsJphzSF+07kTjPHv+Oc14w6QEOfo3Q4hqLJgStUaYB9DBl0TmWg==",
+        "dependencies": {
+          "System.Runtime.CompilerServices.Unsafe": "6.0.0",
+          "System.Text.Encodings.Web": "6.0.0"
+        }
+      },
+      "YamlDotNet": {
+        "type": "Direct",
+        "requested": "[15.1.6, )",
+        "resolved": "15.1.6",
+        "contentHash": "T/cQEK/KHK96Q8kytJ4iUGDXg1/fj2Qtk6rCQeIlHYU1zTeyGVHW0QNZgREQyxZpygGMDMmrXNWt0sj5TsQnjA=="
+      },
+      "System.Runtime.CompilerServices.Unsafe": {
+        "type": "Transitive",
+        "resolved": "6.0.0",
+        "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
+      }
     }
   }
 }

--- a/src/PAModel/packages.lock.json
+++ b/src/PAModel/packages.lock.json
@@ -1,12 +1,21 @@
 {
   "version": 1,
   "dependencies": {
-    "net8.0": {
+    ".NETStandard,Version=v2.0": {
       "Microsoft.Net.Compilers.Toolset.Framework": {
         "type": "Direct",
         "requested": "[4.10.0-3.24216.12, )",
         "resolved": "4.10.0-3.24216.12",
         "contentHash": "Y1T1ZN3cHWToRYZHhRs8xby1tMCkF23Jb//zK+Tdf4ourzwbMQ4GiTRVVFAlWvmA10iVNUyCZucAeLt5XeiDqA=="
+      },
+      "NETStandard.Library": {
+        "type": "Direct",
+        "requested": "[2.0.3, )",
+        "resolved": "2.0.3",
+        "contentHash": "st47PosZSHrjECdjeIzZQbzivYBJFv6P2nv4cj2ypdI204DO+vZ7l5raGMiX4eXMJ53RfOIg+/s4DHVZ54Nu2A==",
+        "dependencies": {
+          "Microsoft.NETCore.Platforms": "1.1.0"
+        }
       },
       "Newtonsoft.Json": {
         "type": "Direct",
@@ -20,6 +29,8 @@
         "resolved": "6.0.0",
         "contentHash": "Vg8eB5Tawm1IFqj4TVK1czJX89rhFxJo9ELqc/Eiq0eXy13RK00eubyU6TJE6y+GQXjyV5gSfiewDUZjQgSE0w==",
         "dependencies": {
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.4",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0"
         }
       },
@@ -29,8 +40,13 @@
         "resolved": "6.0.0",
         "contentHash": "zaJsHfESQvJ11vbXnNlkrR46IaMULk/gHxYsJphzSF+07kTjPHv+Oc14w6QEOfo3Q4hqLJgStUaYB9DBl0TmWg==",
         "dependencies": {
+          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
+          "System.Buffers": "4.5.1",
+          "System.Memory": "4.5.4",
+          "System.Numerics.Vectors": "4.5.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Text.Encodings.Web": "6.0.0"
+          "System.Text.Encodings.Web": "6.0.0",
+          "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
       "YamlDotNet": {
@@ -42,87 +58,47 @@
       "Microsoft.Bcl.AsyncInterfaces": {
         "type": "Transitive",
         "resolved": "6.0.0",
-        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg=="
-      },
-      "Microsoft.Extensions.DependencyInjection": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "V8S3bsm50ig6JSyrbcJJ8bW2b9QLGouz+G1miK3UTaOWmMtFwNNNzUf4AleyDWUmTrWMLNnFSLEQtxmxgNQnNQ==",
+        "contentHash": "UcSjPsst+DfAdJGVDsu346FX0ci0ah+lw3WRtn18NUwEqRt70HaOQ7lI72vy3+1LxtqI3T5GWwV39rQSrCzAeg==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0"
+          "System.Threading.Tasks.Extensions": "4.5.4"
         }
       },
-      "Microsoft.Extensions.DependencyInjection.Abstractions": {
+      "Microsoft.NETCore.Platforms": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "cjWrLkJXK0rs4zofsK4bSdg+jhDLTaxrkXu4gS6Y7MAlCvRyNNgwY/lJi5RDlQOnSZweHqoyvgvbdvQsRIW+hg=="
+        "resolved": "1.1.0",
+        "contentHash": "kz0PEW2lhqygehI/d6XsPCQzD7ff7gUJaVGPVETX611eadGsA3A877GdSlU0LRVMCTH/+P3o2iDTak+S08V2+A=="
       },
-      "Microsoft.Extensions.Logging": {
+      "System.Buffers": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "tvRkov9tAJ3xP51LCv3FJ2zINmv1P8Hi8lhhtcKGqM+ImiTCC84uOPEI4z8Cdq2C3o9e+Aa0Gw0rmrsJD77W+w==",
+        "resolved": "4.5.1",
+        "contentHash": "Rw7ijyl1qqRS0YQD/WycNst8hUUMgrMH4FCn1nNm27M4VxchZ1js3fVjQaANHO5f3sN4isvP4a+Met9Y4YomAg=="
+      },
+      "System.Memory": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "1MbJTHS1lZ4bS4FmsJjnuGJOu88ZzTT2rLvrhW7Ygic+pC0NWA+3hgAen0HRdsocuQXCkUTdFn9yHJJhsijDXw==",
         "dependencies": {
-          "Microsoft.Extensions.DependencyInjection": "8.0.0",
-          "Microsoft.Extensions.Logging.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Options": "8.0.0"
+          "System.Buffers": "4.5.1",
+          "System.Numerics.Vectors": "4.4.0",
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
         }
       },
-      "Microsoft.Extensions.Logging.Abstractions": {
+      "System.Numerics.Vectors": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "arDBqTgFCyS0EvRV7O3MZturChstm50OJ0y9bDJvAcmEPJm0FFpFyjU/JLYyStNGGey081DvnQYlncNX5SJJGA==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0"
-        }
-      },
-      "Microsoft.Extensions.Options": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "JOVOfqpnqlVLUzINQ2fox8evY2SKLYJ3BV8QDe/Jyp21u1T7r45x/R/5QdteURMR5r01GxeJSBBUOCOyaNXA3g==",
-        "dependencies": {
-          "Microsoft.Extensions.DependencyInjection.Abstractions": "8.0.0",
-          "Microsoft.Extensions.Primitives": "8.0.0"
-        }
-      },
-      "Microsoft.Extensions.Primitives": {
-        "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "bXJEZrW9ny8vjMF1JV253WeLhpEVzFo1lyaZu1vQ4ZxWUlVvknZ/+ftFgVheLubb4eZPSwwxBeqS1JkCOjxd8g=="
-      },
-      "Microsoft.PowerFx.Core": {
-        "type": "Transitive",
-        "resolved": "1.2.0",
-        "contentHash": "M9DY6FqWUXUPgjbbHsB3vt7+b4QPFaoKBZ7ixSU7cPgHKzo/aNohzYWxYasXwTV6pamv5gX9AqLuF13RimMPdg==",
-        "dependencies": {
-          "Microsoft.Bcl.AsyncInterfaces": "6.0.0",
-          "Microsoft.PowerFx.Transport.Attributes": "1.2.0",
-          "System.Collections.Immutable": "6.0.0"
-        }
-      },
-      "Microsoft.PowerFx.Transport.Attributes": {
-        "type": "Transitive",
-        "resolved": "1.2.0",
-        "contentHash": "zlvi59W/4MdDJeR2rIL8k633V+FIHtxbhyaurNBZevksNWCZ49AV0bUhpB6cUjD/vwci8ZXXWziw0yYnjXIzNg=="
-      },
-      "System.Collections.Immutable": {
-        "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "l4zZJ1WU2hqpQQHXz1rvC3etVZN+2DLmQMO79FhOTZHMn8tDRr+WU287sbomD0BETlmKDn0ygUgVy9k5xkkJdA==",
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        }
+        "resolved": "4.5.0",
+        "contentHash": "QQTlPTl06J/iiDbJCiepZ4H//BVraReU4O4EoRw1U02H5TLUIT7xn3GnDp9AXPSlJUDyFs4uWjWafNX6WrAojQ=="
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
         "resolved": "6.0.0",
         "contentHash": "/iUeP3tq1S0XdNNoMz5C9twLSrM/TH+qElHkXWaPvuNOt+99G75NrV0OS2EqHx5wMN7popYjpc8oTjC1y16DLg=="
       },
-      "microsoft.powerplatform.powerapps.persistence": {
-        "type": "Project",
+      "System.Threading.Tasks.Extensions": {
+        "type": "Transitive",
+        "resolved": "4.5.4",
+        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg==",
         "dependencies": {
-          "Microsoft.Extensions.Logging": "[8.0.0, )",
-          "Microsoft.PowerFx.Core": "[1.2.0, )",
-          "YamlDotNet": "[15.1.6, )"
+          "System.Runtime.CompilerServices.Unsafe": "4.5.3"
         }
       }
     }

--- a/src/Persistence.Tests/Persistence.Tests.csproj
+++ b/src/Persistence.Tests/Persistence.Tests.csproj
@@ -38,6 +38,7 @@
         <Using Include="FluentAssertions" />
         <Using Include="Microsoft.VisualStudio.TestTools.UnitTesting" />
         <Using Include="Persistence.Tests.Extensions" />
+        <Using Include="Microsoft.Extensions.DependencyInjection" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Persistence/Microsoft.PowerPlatform.PowerApps.Persistence.csproj
+++ b/src/Persistence/Microsoft.PowerPlatform.PowerApps.Persistence.csproj
@@ -35,6 +35,10 @@
     <NoWarn>$(NoWarn);NU1601</NoWarn>
   </PropertyGroup>
 
+  <ItemGroup Label="Global usings">
+      <Using Include="Microsoft.Extensions.DependencyInjection" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="Microsoft.PowerFx.Core" Version="1.2.0" />
     <PackageReference Include="YamlDotNet" Version="$(YamlDotNetVersion)" />


### PR DESCRIPTION
In commit [1c9b22c](https://github.com/microsoft/PowerApps-Tooling/commit/1c9b22cef15b0da9d8afbdb57aebaac3252807ed) back in Dec 2023, all projects in the repo were set to use the same TargetFramework, all sourced from a single shared file.

This accidentally effected the Formulas.Tooling lib, which needs to remain on netstandard2.0 for use in both .NET and .NET Framework versions of PAC CLI.

This PR switches that library back to netstandard2.0, and reverts a few changes since that point for new syntax net8.0 which is not available to netstandard2.0.