### PR TITLE
Fix framework multitargeting

### DIFF
--- a/src/PAModel/Microsoft.PowerPlatform.Formulas.Tools.csproj
+++ b/src/PAModel/Microsoft.PowerPlatform.Formulas.Tools.csproj
@@ -7,6 +7,13 @@
     <RootNamespace>Microsoft.PowerPlatform.Formulas.Tools</RootNamespace>
   </PropertyGroup>
 
+  <PropertyGroup Label="Override Directory.Build.props Settings">
+    <!-- Clear the singular TargetFramework set by Directory.Build.props, so that it doesn't take precidence over the plural TargetFrameworks set above. -->
+    <TargetFramework></TargetFramework> 
+    <!-- Directory.Build.props sets paths assuming a single Target Framework.  Add the framework to the path to prevent overwriting one with the other -->
+    <OutDir>$(OutDir)\$(TargetFramework)</OutDir>
+  </PropertyGroup>
+
   <!-- Nuget Properties -->
   <PropertyGroup>
     <PackageId>Microsoft.PowerPlatform.Formulas.Tools</PackageId>

--- a/src/PAModel/Microsoft.PowerPlatform.Formulas.Tools.csproj
+++ b/src/PAModel/Microsoft.PowerPlatform.Formulas.Tools.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <PropertyGroup Label="Override Directory.Build.props Settings">
-    <!-- Clear the singular TargetFramework set by Directory.Build.props, so that it doesn't take precidence over the plural TargetFrameworks set above. -->
+    <!-- Clear the singular TargetFramework set by Directory.Build.props, so that it doesn't take precedence over the plural TargetFrameworks set above. -->
     <TargetFramework></TargetFramework> 
     <!-- Directory.Build.props sets paths assuming a single Target Framework.  Add the framework to the path to prevent overwriting one with the other -->
     <OutDir>$(OutDir)\$(TargetFramework)</OutDir>


### PR DESCRIPTION
The goal of PR #684 was to fix the Microsoft.PowerPlatform.Formulas.Tools nuget package by returning a netstandard2.0 version for consumption within full .NET Framework projects such as the net48 version of PAC CLI.  

While that resulted in a nuget package with both net8.0 and netstandard2.0 folders, the actual DLLs in both of those folders were in fact the net8.0 version, as I was not overriding a few values coming from the parent Directory.Build.props file.