### PR TITLE
Yaml Validator Bug: same file names in different folder cause error

### DIFF
--- a/src/YamlValidator/YamlLoader.cs
+++ b/src/YamlValidator/YamlLoader.cs
@@ -25,7 +25,7 @@ public class YamlLoader
                 var yamlFiles = Directory.EnumerateFiles(filePath, "*" + Constants.YamlFileExtension, SearchOption.AllDirectories);
                 foreach (var filename in yamlFiles)
                 {
-                    var fileName = Path.GetFileName(filename);
+                    var fileName = Path.GetRelativePath(filePath, filename);
                     var yamlText = Utility.ReadFileData(filename);
                     deserializedYaml.Add(fileName, yamlText);
                 }

--- a/src/YamlValidator/YamlLoader.cs
+++ b/src/YamlValidator/YamlLoader.cs
@@ -25,7 +25,7 @@ public class YamlLoader
                 var yamlFiles = Directory.EnumerateFiles(filePath, "*" + Constants.YamlFileExtension, SearchOption.AllDirectories);
                 foreach (var filename in yamlFiles)
                 {
-                    var fileName = Path.GetRelativePath(filePath, filename);
+                    var fileName = Path.GetFullPath(filename);
                     var yamlText = Utility.ReadFileData(filename);
                     deserializedYaml.Add(fileName, yamlText);
                 }


### PR DESCRIPTION
## Problem
- File names are stored in a dictionary so that they can be output in the console
- Two of the same file names in different folders cause an error when recursively traversing the folders due to a repeated key (was found when traversing the Persistence.Tests Valid-CI test data folder)

## Changes
The way file names are stored in a dictionary and output. Specifically, use the relative path of a file as the name of the file instead of just the filename.

## Validation
- Re-ran unit tests, manual validation
