### PR TITLE
Treat NU1603 warning as not error

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -26,6 +26,10 @@
   <PropertyGroup Label="Code Analysis config for VS IDE"
                  Condition="'$(BuildingInsideVisualStudio)' == 'true'">
         <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+        <!-- Warning treated as error for dotnet compiler, see Pr #660 and this for context
+            https://github.com/dotnet/core/blob/main/release-notes/8.0/known-issues.md#802xx-sdk-is-not-compatible-with-178-for-some-scenarios
+        -->
+        <WarningsNotAsErrors>NU1603</WarningsNotAsErrors>
         <CodeAnalysisTreatWarningsAsErrors>false</CodeAnalysisTreatWarningsAsErrors>
     </PropertyGroup>
 


### PR DESCRIPTION
### Problem
CI builds are failing due to dotnet compiler version warnings being treated as errors. [Example](https://github.com/microsoft/PowerApps-Tooling/actions/runs/9895983203/job/27337098234?pr=697)
Context: 
1. https://github.com/dotnet/core/blob/46eab6765980914d9481ccecebec302153621c45/release-notes/8.0/known-issues.md?plain=1#L17
2. https://github.com/microsoft/PowerApps-Tooling/pull/660

### Fix
This specific warning is not treated as an error


