### PR TITLE
Add custom exception for errors from Yaml Validator Library

### DIFF
--- a/src/YamlValidator/SchemaLoader.cs
+++ b/src/YamlValidator/SchemaLoader.cs
@@ -22,7 +22,7 @@ internal class SchemaLoader
             var assemblyName = assembly.GetName().Name;
             if (fileStream == null)
             {
-                throw new IOException($"Resource {file} could not found in assembly {assemblyName}");
+                throw new YamlValidatorLibraryException($"The schema could not be loaded from assembly.");
             }
             using var streamReader = new StreamReader(fileStream);
             var jsonSchemaString = streamReader.ReadToEnd();
@@ -45,7 +45,7 @@ internal class SchemaLoader
         }
         if (node == null)
         {
-            throw new InvalidDataException("Schema was not able to be read into memory");
+            throw new YamlValidatorLibraryException("The schema could not be serialized from the assembly.");
         }
         return node;
     }

--- a/src/YamlValidator/ValidatorError.cs
+++ b/src/YamlValidator/ValidatorError.cs
@@ -31,9 +31,9 @@ public class ValidatorError
             foreach (var error in Errors)
             {
                 var errType = string.IsNullOrEmpty(error.Key) ? "Error" : error.Key;
-                errString += $"\t{errType}: {error.Value}\n";
+                errString += $"\t\t- {errType}: {error.Value}\n";
             }
         }
-        return $"InstanceLocation: {InstanceLocation}\nSchemaPath: {SchemaPath}\nErrors:\n{errString}";
+        return $"\t- InstanceLocation: {InstanceLocation}\n\t- SchemaPath: {SchemaPath}\n\t- Errors:\n{errString}";
     }
 }

--- a/src/YamlValidator/YamlValidatorLibraryException.cs
+++ b/src/YamlValidator/YamlValidatorLibraryException.cs
@@ -1,0 +1,12 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.YamlValidator;
+public class YamlValidatorLibraryException : Exception
+{
+    public string Reason { get; }
+    public YamlValidatorLibraryException(string reason)
+    {
+        Reason = reason;
+    }
+}

--- a/src/YamlValidator/YamlValidatorLibraryException.cs
+++ b/src/YamlValidator/YamlValidatorLibraryException.cs
@@ -4,9 +4,7 @@
 namespace Microsoft.PowerPlatform.PowerApps.Persistence.YamlValidator;
 public class YamlValidatorLibraryException : Exception
 {
-    public string Reason { get; }
-    public YamlValidatorLibraryException(string reason)
+    public YamlValidatorLibraryException(string reason) : base(message: reason)
     {
-        Reason = reason;
     }
 }


### PR DESCRIPTION
- Added custom exception to handle expected exceptions from YamlValidator. This will be used in PAC CLI to indicate the error came from the YamlValidator library if the schema couldn't be loaded from the assembly when the IValidatorFactory is asked to create a new validator.

- Also changed the printing format of Validator Results (inconsequential)

## Problem
Custom exception to be used by library callers to handle errors

## Solution

What are we doing to solve this issue?

## Changes

- Log what was changed
- Log what was changed
- Log what was changed

## Validation

- How did you verify that this issue is truly fixed?
