### PR TITLE
prevent 'error IDE0036: Modifiers are not ordered'

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -36,6 +36,7 @@ trim_trailing_whitespace = true
 file_header_template = Copyright (c) Microsoft Corporation.\nLicensed under the MIT License.
 
 # Naming rules
+dotnet_diagnostic.IDE0036.severity = none
 
 dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
 dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface

--- a/.editorconfig
+++ b/.editorconfig
@@ -36,7 +36,6 @@ trim_trailing_whitespace = true
 file_header_template = Copyright (c) Microsoft Corporation.\nLicensed under the MIT License.
 
 # Naming rules
-dotnet_diagnostic.IDE0036.severity = none
 
 dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
 dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface

--- a/src/Persistence/Collections/ControlPropertiesCollection.cs
+++ b/src/Persistence/Collections/ControlPropertiesCollection.cs
@@ -7,7 +7,7 @@ namespace Microsoft.PowerPlatform.PowerApps.Persistence.Collections;
 
 public class ControlPropertiesCollection : NamedItemsCollection<ControlProperty>
 {
-    private readonly static Func<ControlProperty, string> _keySelector = v => v.Name;
+    private static readonly Func<ControlProperty, string> _keySelector = v => v.Name;
 
     public ControlPropertiesCollection() : base(_keySelector)
     {

--- a/src/Persistence/Collections/CustomPropertiesCollection.cs
+++ b/src/Persistence/Collections/CustomPropertiesCollection.cs
@@ -7,7 +7,7 @@ namespace Microsoft.PowerPlatform.PowerApps.Persistence.Collections;
 
 public class CustomPropertiesCollection : NamedItemsCollection<CustomProperty>
 {
-    private readonly static Func<CustomProperty, string> _keySelector = v => v.Name;
+    private static readonly Func<CustomProperty, string> _keySelector = v => v.Name;
 
     public CustomPropertiesCollection() : base(_keySelector)
     {

--- a/src/Persistence/Collections/CustomPropertyParametersCollection.cs
+++ b/src/Persistence/Collections/CustomPropertyParametersCollection.cs
@@ -7,7 +7,7 @@ namespace Microsoft.PowerPlatform.PowerApps.Persistence.Collections;
 
 public class CustomPropertyParametersCollection : NamedItemsCollection<CustomPropertyParameter>
 {
-    private readonly static Func<CustomPropertyParameter, string> _keySelector = v => v.Name;
+    private static readonly Func<CustomPropertyParameter, string> _keySelector = v => v.Name;
 
     public CustomPropertyParametersCollection() : base(_keySelector)
     {

--- a/src/Persistence/Extensions/YamlExtensions.cs
+++ b/src/Persistence/Extensions/YamlExtensions.cs
@@ -8,7 +8,7 @@ namespace Microsoft.PowerPlatform.PowerApps.Persistence.Extensions;
 
 public static class YamlExtensions
 {
-    static internal readonly char[] LineTerminators = new char[] { '\r', '\n', '\x85', '\x2028', '\x2029' };
+    internal static readonly char[] LineTerminators = new char[] { '\r', '\n', '\x85', '\x2028', '\x2029' };
 
     public static ScalarStyle DetermineScalarStyleForProperty(this string? property)
     {

--- a/src/Persistence/PaYaml/Models/NamedObjectMapping.cs
+++ b/src/Persistence/PaYaml/Models/NamedObjectMapping.cs
@@ -13,7 +13,7 @@ namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models;
 public class NamedObjectMapping<TValue> : NamedObjectMappingBase<string, TValue, NamedObject<TValue>>, INamedObjectCollection<TValue>
     where TValue : notnull
 {
-    private readonly static StringComparer DefaultComparer = StringComparer.Ordinal;
+    private static readonly StringComparer DefaultComparer = StringComparer.Ordinal;
 
     public NamedObjectMapping()
         : this(DefaultComparer)

--- a/src/Persistence/PaYaml/Models/NamedObjectSequence.cs
+++ b/src/Persistence/PaYaml/Models/NamedObjectSequence.cs
@@ -9,7 +9,7 @@ namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models;
 public class NamedObjectSequence<TValue> : NamedObjectSequenceBase<string, TValue, NamedObject<TValue>>, INamedObjectCollection<TValue>
     where TValue : notnull
 {
-    private readonly static StringComparer DefaultComparer = StringComparer.Ordinal;
+    private static readonly StringComparer DefaultComparer = StringComparer.Ordinal;
 
     public NamedObjectSequence()
         : this(DefaultComparer)


### PR DESCRIPTION
Using `build ci` at githash 5b4aa54 gives 'error IDE0036: Modifiers are not ordered'

/Users/jb/src/github.com/microsoft/PowerApps-Tooling/src/Persistence/Collections/ControlPropertiesCollection.cs(10,5): error IDE0036: Modifiers are not ordered (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0036) [/Users/jb/src/github.com/microsoft/PowerApps-Tooling/src/Persistence/Microsoft.PowerPlatform.PowerApps.Persistence.csproj] /Users/jb/src/github.com/microsoft/PowerApps-Tooling/src/Persistence/Collections/CustomPropertiesCollection.cs(10,5): error IDE0036: Modifiers are not ordered (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0036) [/Users/jb/src/github.com/microsoft/PowerApps-Tooling/src/Persistence/Microsoft.PowerPlatform.PowerApps.Persistence.csproj] /Users/jb/src/github.com/microsoft/PowerApps-Tooling/src/Persistence/Collections/CustomPropertyParametersCollection.cs(10,5): error IDE0036: Modifiers are not ordered (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0036) [/Users/jb/src/github.com/microsoft/PowerApps-Tooling/src/Persistence/Microsoft.PowerPlatform.PowerApps.Persistence.csproj] /Users/jb/src/github.com/microsoft/PowerApps-Tooling/src/Persistence/Extensions/YamlExtensions.cs(11,5): error IDE0036: Modifiers are not ordered (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0036) [/Users/jb/src/github.com/microsoft/PowerApps-Tooling/src/Persistence/Microsoft.PowerPlatform.PowerApps.Persistence.csproj] /Users/jb/src/github.com/microsoft/PowerApps-Tooling/src/Persistence/PaYaml/Models/NamedObjectMapping.cs(16,5): error IDE0036: Modifiers are not ordered (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0036) [/Users/jb/src/github.com/microsoft/PowerApps-Tooling/src/Persistence/Microsoft.PowerPlatform.PowerApps.Persistence.csproj] /Users/jb/src/github.com/microsoft/PowerApps-Tooling/src/Persistence/PaYaml/Models/NamedObjectSequence.cs(12,5): error IDE0036: Modifiers are not ordered (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0036) [/Users/jb/src/github.com/microsoft/PowerApps-Tooling/src/Persistence/Microsoft.PowerPlatform.PowerApps.Persistence.csproj]
    0 Warning(s)
    6 Error(s)

If this is related to an issue open in GitHub, please link it to this ticket and put the URL here.

## Problem

Cloning the repo and following its instructions to build using `build ci` results in a failed build. The error code indicates an error in the expected order for modifiers.

## Solution

Either fix the modifier order of the files identified, or take my change to ignore them.

## Changes

- I changed .editorconfig to ignore IDE0036 errors. AFAIK, modifier order does not impact the resulting assembly.

## Validation

- Successfully built PA tools w/this small change. 
