### PR TITLE
V3 YAML schema for Data Sources

### DIFF
--- a/src/Persistence.Tests/PaYaml/Serialization/PaYamlSerializerTests.cs
+++ b/src/Persistence.Tests/PaYaml/Serialization/PaYamlSerializerTests.cs
@@ -46,6 +46,22 @@ public class PaYamlSerializerTests : VSTestBase
     }
 
     [TestMethod]
+    [DataRow(@"_TestData/SchemaV3_0/Examples/Src/DataSources/DataSources1.pa.yaml")]
+    public void DeserializeExamplePaYamlDataSources(string path)
+    {
+        var paFileRoot = PaYamlSerializer.Deserialize<PaModule>(File.ReadAllText(path));
+        paFileRoot.ShouldNotBeNull();
+
+        // Top level properties
+        paFileRoot.DataSources.ShouldNotBeNull();
+        paFileRoot.App.Should().BeNull();
+        paFileRoot.ComponentDefinitions.Should().BeNullOrEmpty();
+        paFileRoot.Screens.Should().BeNullOrEmpty();
+
+        paFileRoot.DataSources.Should().HaveCount(3);
+    }
+
+    [TestMethod]
     [DataRow(@"_TestData/SchemaV3_0/Examples/Src/Screens/Screen1.pa.yaml", 2, 8, 14, 2, 3)]
     [DataRow(@"_TestData/SchemaV3_0/Examples/Src/Screens/FormsScreen2.pa.yaml", 0, 1, 62, 0, 0)]
     [DataRow(@"_TestData/SchemaV3_0/Examples/Src/Screens/ComponentsScreen4.pa.yaml", 0, 6, 6, 0, 0)]

--- a/src/Persistence.Tests/PaYaml/Serialization/PaYamlSerializerTests.cs
+++ b/src/Persistence.Tests/PaYaml/Serialization/PaYamlSerializerTests.cs
@@ -156,6 +156,7 @@ public class PaYamlSerializerTests : VSTestBase
     [DataRow(@"_TestData/SchemaV3_0/FullSchemaUses/App.pa.yaml")]
     [DataRow(@"_TestData/SchemaV3_0/FullSchemaUses/Screens-general-controls.pa.yaml")]
     [DataRow(@"_TestData/SchemaV3_0/FullSchemaUses/Screens-with-components.pa.yaml")]
+    [DataRow(@"_TestData/SchemaV3_0/Examples/Src/DataSources/DataSources1.pa.yaml")]
     public void RoundTripFromYaml(string path)
     {
         var originalYaml = File.ReadAllText(path);

--- a/src/Persistence/PaYaml/Models/SchemaV3/DataSourceInstance.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV3/DataSourceInstance.cs
@@ -1,10 +1,18 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using YamlDotNet.Serialization;
+
 namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.SchemaV3;
+
+public enum DataSourceInstanceType
+{
+    DataverseTable,
+}
 
 public record DataSourceInstance
 {
-    public required string Type { get; init; }
+    [YamlMember(DefaultValuesHandling = DefaultValuesHandling.Preserve)]
+    public required DataSourceInstanceType Type { get; init; }
     public string? TableLogicalName { get; init; }
 }

--- a/src/Persistence/PaYaml/Models/SchemaV3/DataSourceInstance.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV3/DataSourceInstance.cs
@@ -1,0 +1,10 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.SchemaV3;
+
+public record DataSourceInstance
+{
+    public required string Type { get; init; }
+    public string? TableLogicalName { get; init; }
+}

--- a/src/Persistence/PaYaml/Models/SchemaV3/PaModule.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV3/PaModule.cs
@@ -11,4 +11,5 @@ public record PaModule
     public AppInstance? App { get; init; }
     public NamedObjectMapping<ComponentDefinition> ComponentDefinitions { get; init; } = new();
     public NamedObjectMapping<ScreenInstance> Screens { get; init; } = new();
+    public NamedObjectMapping<DataSourceInstance> DataSources { get; init; } = new();
 }

--- a/src/schemas-tests/pa-yaml/v3.0/Examples/Src/DataSources/DataSources1.pa.yaml
+++ b/src/schemas-tests/pa-yaml/v3.0/Examples/Src/DataSources/DataSources1.pa.yaml
@@ -1,0 +1,10 @@
+DataSources:
+  Accounts:
+    Type: DataverseTable
+    TableLogicalName: account
+  Contacts:
+    Type: DataverseTable
+    TableLogicalName: contact
+  Users:
+    Type: DataverseTable
+    TableLogicalName: systemuser


### PR DESCRIPTION
YAML V3 schema for Data Sources

1. The initial version of this schema will define the necessary structure for Dataverse data sources within the current environment.
2. The `DataSourceInstance ` type is a flattened structure that incorporates all potential properties of a YAML data source, with only one required property: `Type`.
3. The `Type `property is mandatory and serves to identify the specific polymorphic type. Validation of this property will occur during parsing.

Below is a sample v3 pa yaml with dataverse datasources from current environment.
![image](https://github.com/user-attachments/assets/656739dd-0789-442b-ae68-cfdadc17d669)

## Changes

- Introduced a top-level node specifically for Data Sources.
- Defined distinct types for various Data Source properties.
- Implemented unit tests to validate the Data Source schema.

## Validation

- Local debugging/testing
