### PR TITLE
added detection for duplicate names in yaml sequence

### DIFF
--- a/src/Persistence.Tests/PaYaml/Serialization/PaYamlSerializerTests.cs
+++ b/src/Persistence.Tests/PaYaml/Serialization/PaYamlSerializerTests.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using Microsoft.PowerPlatform.PowerApps.Persistence;
+using Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models;
 using Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.SchemaV3;
 using Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Serialization;
 
@@ -150,6 +152,14 @@ public class PaYamlSerializerTests : VSTestBase
         screen.Properties.Should().BeNullOrEmpty();
         screen.Children.Should().HaveCount(2)
             .And.ContainNames("Label1", "TextInput1");
+    }
+
+    [TestMethod]
+    public void DeserializeDuplicateControlNamesShouldFail()
+    {
+        var path = @"_TestData/InvalidYaml-CI/duplicate-control-in-sequence.pa.yaml";
+        var ex = Assert.ThrowsException<PersistenceLibraryException>(() => PaYamlSerializer.Deserialize<NamedObjectSequence<ControlInstance>>(File.ReadAllText(path)));
+        ex.ErrorCode.Should().Be(PersistenceErrorCode.DuplicateNameInSequence);
     }
 
     #endregion

--- a/src/Persistence.Tests/_TestData/InvalidYaml-CI/duplicate-control-in-sequence.pa.yaml
+++ b/src/Persistence.Tests/_TestData/InvalidYaml-CI/duplicate-control-in-sequence.pa.yaml
@@ -1,0 +1,10 @@
+- Label1:
+    Control: Label
+    Properties:
+      X: =40
+      Y: =40
+- Label1:
+    Control: Label
+    Properties:
+      X: =60
+      Y: =60

--- a/src/Persistence/PaYaml/Serialization/PaYamlSerializer.cs
+++ b/src/Persistence/PaYaml/Serialization/PaYamlSerializer.cs
@@ -115,6 +115,10 @@ public static class PaYamlSerializer
 
             return value;
         }
+        catch (YamlException ex) when (ex.InnerException is ArgumentException && ex.InnerException.Message.Contains("An item with the same key has already been added"))
+        {
+            throw PersistenceLibraryException.FromYamlException(ex, PersistenceErrorCode.DuplicateNameInSequence);
+        }
         catch (YamlException ex)
         {
             throw PersistenceLibraryException.FromYamlException(ex, PersistenceErrorCode.YamlInvalidSyntax);

--- a/src/Persistence/PaYaml/Serialization/PaYamlSerializer.cs
+++ b/src/Persistence/PaYaml/Serialization/PaYamlSerializer.cs
@@ -115,13 +115,13 @@ public static class PaYamlSerializer
 
             return value;
         }
-        catch (YamlException ex) when (ex.InnerException is ArgumentException && ex.InnerException.Message.Contains("An item with the same key has already been added"))
-        {
-            throw PersistenceLibraryException.FromYamlException(ex, PersistenceErrorCode.DuplicateNameInSequence);
-        }
         catch (YamlException ex)
         {
-            throw PersistenceLibraryException.FromYamlException(ex, PersistenceErrorCode.YamlInvalidSyntax);
+            var errorCode = PersistenceErrorCode.YamlInvalidSyntax;
+            if (ex.InnerException is ArgumentException && ex.InnerException.Message.Contains("An item with the same key has already been added"))
+                errorCode = PersistenceErrorCode.DuplicateNameInSequence;
+
+            throw PersistenceLibraryException.FromYamlException(ex, errorCode);
         }
 
         // TODO: Consider using FluentValidation nuget package to validate the deserialized object

--- a/src/Persistence/PersistenceErrorCode.cs
+++ b/src/Persistence/PersistenceErrorCode.cs
@@ -26,6 +26,7 @@ public enum PersistenceErrorCode
     InvalidEditorStateJson = 3300,
     ControlInstanceInvalid = 3501,
     RoundTripValidationFailed = 3502,
+    DuplicateNameInSequence = 3503,
 
     //
     MsappArchiveError = 5000,
@@ -64,6 +65,7 @@ public static class PersistenceErrorCodeExtensions
             PersistenceErrorCode.InvalidEditorStateJson => "An editor state json file could not be deserialized due to being invalid.",
             PersistenceErrorCode.ControlInstanceInvalid => "A control instance object in YAML has an invalid state.",
             PersistenceErrorCode.RoundTripValidationFailed => "Round trip yaml validation failed.",
+            PersistenceErrorCode.DuplicateNameInSequence => "An item name was duplicated.",
             PersistenceErrorCode.MsappArchiveError => "An error was detected in an msapp file.",
             PersistenceErrorCode._LastErrorExclusive => throw new InvalidOperationException("The error code is out of range."),
             _ => "An exception occurred in the persistence library.",


### PR DESCRIPTION
Added specific error code and detection for duplicate names in yaml sequence.
Example:
```
- MyControl:
    Control: Label
- MyControl:
    Control: Label
```