### PR TITLE
ControlInstance type now supports versions

### DIFF
--- a/schemas/pa-yaml/v3.0/pa.schema.yaml
+++ b/schemas/pa-yaml/v3.0/pa.schema.yaml
@@ -118,7 +118,7 @@ definitions:
     $comment: Defines reusable schema for validating the pattern allowed for control type identifiers.
     type: string
     pattern: |-
-      ^([A-Z][a-zA-Z0-9]*/)?[A-Z][a-zA-Z0-9]*$
+      ^([A-Z][a-zA-Z0-9]*/)?[A-Z][a-zA-Z0-9]*(@\d+\.\d+\.\d+)?$
 
   ControlTypeId-disallowed-types:
     enum:

--- a/src/Persistence/PaYaml/Models/SchemaV3/ControlInstance.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV3/ControlInstance.cs
@@ -12,13 +12,13 @@ public record ControlInstance : IPaControlInstanceContainer
     public ControlInstance() { }
 
     [SetsRequiredMembers]
-    public ControlInstance(string controlTypeId)
+    public ControlInstance(string controlType)
     {
-        ControlTypeId = controlTypeId ?? throw new ArgumentNullException(nameof(controlTypeId));
+        ControlType = controlType ?? throw new ArgumentNullException(nameof(controlType));
     }
 
     [property: YamlMember(Alias = "Control")]
-    public required string ControlTypeId { get; init; }
+    public required string ControlType { get; init; }
 
     public string? Variant { get; init; }
 

--- a/src/schemas-tests/pa-yaml/v3.0/FullSchemaUses/Screens-general-controls.pa.yaml
+++ b/src/schemas-tests/pa-yaml/v3.0/FullSchemaUses/Screens-general-controls.pa.yaml
@@ -15,7 +15,7 @@ Screens:
 
       # Purposely set out of name sorting order to ensure ordering is maintained
       - ctrlA:
-          Control: Label
+          Control: Label@1.2.3
           Variant: variantA
           Group: Group1
           Properties:

--- a/src/schemas/pa-yaml/v3.0/pa.schema.yaml
+++ b/src/schemas/pa-yaml/v3.0/pa.schema.yaml
@@ -126,10 +126,11 @@ definitions:
     $comment: Defines reusable schema for validating the pattern allowed for control type identifiers.
     type: string
     # The value of this identifier takes the format:
-    #   ( <invariantFamily> '/' )? <invariantName>
+    #   ( <invariantFamily> '/' )? <invariantName> ( '@' <version> )?
     #   Where the set of allowed characters is limited.
+    #   Where <version> is a 3-part version number (e.g. "1.20.30").
     pattern: |-
-      ^([A-Z][a-zA-Z0-9]*/)?[A-Z][a-zA-Z0-9]*$
+      ^([A-Z][a-zA-Z0-9]*/)?[A-Z][a-zA-Z0-9]*(@\d+\.\d+\.\d+)?$
 
   ControlTypeId-disallowed-types:
     enum:


### PR DESCRIPTION
- Rename `ControlInstance.ControlTypeId` to `ControlType`  
   Now that we'll be supporting control type versions, renaming this property keeps it's semantics from getting confused with the actual `ControlTypeIdentifier`
- Updated schema to allow for version numbers

