### PR TITLE
added method to detect if a yaml fragment is a sequence

### DIFF
--- a/src/Persistence.Tests/PaYaml/Serialization/PaYamlSerializerTests.cs
+++ b/src/Persistence.Tests/PaYaml/Serialization/PaYamlSerializerTests.cs
@@ -198,4 +198,21 @@ public class PaYamlSerializerTests : VSTestBase
     }
 
     #endregion
+
+    #region Is Sequence checks
+
+    [TestMethod]
+    [DataRow(@"_TestData/SchemaV3_0/Examples/Src/App.pa.yaml", false)]
+    [DataRow(@"_TestData/SchemaV3_0/Examples/Src/Screens/Screen1.pa.yaml", false)]
+    [DataRow(@"_TestData/SchemaV3_0/Examples/Src/Components/MyHeaderComponent.pa.yaml", false)]
+    [DataRow(@"_TestData/ValidYaml-CI/With-list-of-controls.pa.yaml", true)]
+    [DataRow(@"_TestData/InvalidYaml/Dupliacte-Keys.pa.yaml", false)]
+    public void IsSequenceCheckShouldWorkAsExpected(string path, bool expected)
+    {
+        var yaml = File.ReadAllText(path);
+        var isSequence = PaYamlSerializer.CheckIsSequence(yaml);
+        isSequence.Should().Be(expected);
+    }
+
+    #endregion
 }

--- a/src/Persistence/PaYaml/Serialization/PaYamlSerializer.cs
+++ b/src/Persistence/PaYaml/Serialization/PaYamlSerializer.cs
@@ -128,5 +128,45 @@ public static class PaYamlSerializer
         // See: fluentvalidation.net
         // See: https://www.youtube.com/watch?v=jblRYDMTtvg
     }
+
+    /// <summary>
+    /// checks the input source is a sequence of YAML items.
+    /// </summary>
+    /// <param name="yaml">The YAML text to check.</param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public static bool CheckIsSequence(string yaml)
+    {
+        _ = yaml ?? throw new ArgumentNullException(nameof(yaml));
+
+        using var reader = new StringReader(yaml);
+        return CheckIsSequence(reader);
+    }
+
+    /// <summary>
+    /// checks the input source is a sequence of YAML items.
+    /// </summary>
+    /// <param name="reader"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    public static bool CheckIsSequence(StringReader reader)
+    {
+        ArgumentNullException.ThrowIfNull(reader);
+
+        var builder = new DeserializerBuilder()
+            .IgnoreUnmatchedProperties()
+            .WithTypeConverter(new YamlSequenceTesterConverter());
+        var deserializer = builder.Build();
+        try
+        {
+            var results = deserializer.Deserialize<object[]>(reader);
+            return results is not null;
+        }
+        catch (YamlException)
+        {
+            return false;
+        }
+    }
+
     #endregion
 }

--- a/src/Persistence/PaYaml/Serialization/YamlSequenceTesterConverter.cs
+++ b/src/Persistence/PaYaml/Serialization/YamlSequenceTesterConverter.cs
@@ -1,0 +1,44 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections;
+using YamlDotNet.Core;
+using YamlDotNet.Core.Events;
+using YamlDotNet.Serialization;
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Serialization;
+
+/// <summary>
+/// custom converter used to test if the input is a sequence of YAML items.
+/// </summary>
+internal sealed class YamlSequenceTesterConverter : IYamlTypeConverter
+{
+    public bool Accepts(Type type)
+    {
+        return type == typeof(List<object>) || type.IsSubclassOf(typeof(List<object>)) ||
+            type == typeof(IList<object>) || type.IsSubclassOf(typeof(IList<object>)) ||
+            type == typeof(IEnumerable) || type.IsSubclassOf(typeof(IEnumerable)) ||
+            type == typeof(IEnumerable<object>) || type.IsSubclassOf(typeof(IEnumerable<object>)) ||
+            type == typeof(object[]);
+    }
+
+    public object? ReadYaml(IParser parser, Type type)
+    {
+        if (parser.Current is not SequenceStart)
+            throw new YamlException(parser.Current!.Start, parser.Current.End, $"Expected sequence start but got {parser.Current.GetType().Name}");
+
+        while (!parser.Accept<SequenceEnd>(out _))
+        {
+            parser.MoveNext();
+        }
+
+        parser.MoveNext();
+
+        return Array.Empty<object>();
+    }
+
+    public void WriteYaml(IEmitter emitter, object? value, Type type)
+    {
+        throw new NotImplementedException();
+    }
+}

--- a/src/Persistence/PaYaml/Serialization/YamlSequenceTesterConverter.cs
+++ b/src/Persistence/PaYaml/Serialization/YamlSequenceTesterConverter.cs
@@ -15,9 +15,7 @@ internal sealed class YamlSequenceTesterConverter : IYamlTypeConverter
 {
     public bool Accepts(Type type)
     {
-        return type == typeof(List<object>) || type.IsSubclassOf(typeof(List<object>)) ||
-            type == typeof(IList<object>) || type.IsSubclassOf(typeof(IList<object>)) ||
-            type == typeof(IEnumerable) || type.IsSubclassOf(typeof(IEnumerable)) ||
+        return type == typeof(IEnumerable) || type.IsSubclassOf(typeof(IEnumerable)) ||
             type == typeof(IEnumerable<object>) || type.IsSubclassOf(typeof(IEnumerable<object>)) ||
             type == typeof(object[]);
     }


### PR DESCRIPTION
Added a new `CheckIsSequence` method to detect if a yaml fragment is a sequence. It internally creates a new YamlDotNet deserializer that uses the custom type converter `YamlSequenceTesterConverter`.
This converter will simply check if the YAML fragment starts with the `SequenceStart` event and ends with `SequenceEnd`.

The following benchmark shows the results of a few deserialization methods:
- Direct deserialization to `IEnumerable<object>` using a basic YamlDotNet deserializer
- Direct deserialization to `object[]` using a basic YamlDotNet deserializer
- Direct deserialization to `Dictionary<string,object>[]` using a basic YamlDotNet deserializer
- the newly introduced `CheckIsSequence` method
- deserialization using the v2 deserializer
- deserialization using the v3 deserializer
![image](https://github.com/user-attachments/assets/24ebe923-0911-4318-b044-f72980d99105)

results from `CheckIsSequence` are not so different from Direct deserialization to `IEnumerable<object>`. We might decide to remove the custom `YamlSequenceTesterConverter` in the future and rely directly on the base library instead.
