### PR TITLE
Fixing regex for components in v3 schema

### DIFF
--- a/schemas/pa-yaml/v3.0/pa.schema.yaml
+++ b/schemas/pa-yaml/v3.0/pa.schema.yaml
@@ -230,7 +230,7 @@ definitions:
       The format is: <publisher-prefix> '_' <JS-Namespace> '.' <JS-ClassName>
     type: string
     pattern: |-
-      ^([a-z][a-z0-9]{1,7})_([a-zA-Z0-9]\.)+[a-zA-Z0-9]+*$
+      ^([a-z][a-z0-9]{1,7})_([a-zA-Z0-9]\.)+[a-zA-Z0-9]+$
 
   ComponentDefinitions-name-instance-map:
     type: object

--- a/src/schemas/pa-yaml/v3.0/pa.schema.yaml
+++ b/src/schemas/pa-yaml/v3.0/pa.schema.yaml
@@ -252,7 +252,7 @@ definitions:
     type: string
     # TODO: The JS regex pattern doesn't easily support unicode chars which are valid JS identifiers.
     pattern: |-
-      ^([a-z][a-z0-9]{1,7})_([a-zA-Z0-9]\.)+[a-zA-Z0-9]+*$
+      ^([a-z][a-z0-9]{1,7})_([a-zA-Z0-9]\.)+[a-zA-Z0-9]+$
 
   ComponentDefinitions-name-instance-map:
     type: object


### PR DESCRIPTION
## Problem

There is a small error in the regex for Components in the YAML V3 Schema

## Solution

I have updated the regex removing an unnecessary character that led to validation failures

## Changes

- Removed a '*' at the end of the Component regex in v3 pa.schema

## Validation

- How did you verify that this issue is truly fixed?
