### PR TITLE
added support for namemaps on control properties

### DIFF
--- a/src/Persistence.Tests/PaYaml/Serialization/PaYamlSerializerTests.cs
+++ b/src/Persistence.Tests/PaYaml/Serialization/PaYamlSerializerTests.cs
@@ -28,37 +28,6 @@ public class PaYamlSerializerTests : VSTestBase
         paModule.App.Properties.Should().ContainName("Bar").WhoseNamedObject.Start.Should().Be(new(4, 9));
     }
 
-    [TestMethod]
-    public void DeserializeDropDownPropertiesNameMap()
-    {
-        var yaml = """
-            Screens:
-              Screen1:
-                Children:
-                  - DropDown1:
-                      Control: Classic/DropDown
-                      PropertiesNameMaps:
-                        Items:
-                          Value: Title
-            """;
-        var paModule = PaYamlSerializer.Deserialize<PaModule>(yaml);
-        paModule.ShouldNotBeNull();
-        paModule.Screens.Should().NotBeNull()
-            .And.ContainNames("Screen1");
-
-        var screen = paModule.Screens["Screen1"];
-        screen.Children.Should().NotBeNull()
-            .And.ContainNames("DropDown1");
-
-        var dropDown = screen.Children!["DropDown1"];
-        dropDown.PropertiesNameMaps.Should().NotBeNull()
-            .And.ContainNames("Items");
-
-        var itemsNameMap = dropDown.PropertiesNameMaps!["Items"];
-        itemsNameMap.Should().ContainKey("Value")
-            .WhoseValue.Should().Be("Title");
-    }
-
     #region Deserialize Examples
 
     [TestMethod]

--- a/src/Persistence.Tests/PaYaml/Serialization/PaYamlSerializerTests.cs
+++ b/src/Persistence.Tests/PaYaml/Serialization/PaYamlSerializerTests.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT License.
 
 using Microsoft.PowerPlatform.PowerApps.Persistence;
-using Microsoft.PowerPlatform.PowerApps.Persistence.Models;
 using Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models;
 using Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.SchemaV3;
 using Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Serialization;

--- a/src/Persistence/PaYaml/Models/SchemaV3/ControlInstance.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV3/ControlInstance.cs
@@ -37,5 +37,7 @@ public record ControlInstance : IPaControlInstanceContainer
 
     public NamedObjectMapping<PFxExpressionYaml>? Properties { get; init; }
 
+    public NamedObjectMapping<IDictionary<string, string>>? PropertiesNameMaps { get; init; }
+
     public NamedObjectSequence<ControlInstance>? Children { get; init; }
 }

--- a/src/Persistence/PaYaml/Models/SchemaV3/ControlInstance.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV3/ControlInstance.cs
@@ -37,7 +37,7 @@ public record ControlInstance : IPaControlInstanceContainer
 
     public NamedObjectMapping<PFxExpressionYaml>? Properties { get; init; }
 
-    public NamedObjectMapping<IDictionary<string, string>>? PropertiesNameMaps { get; init; }
+    public NamedObjectMapping<NamedObjectMapping<string>>? PropertiesNameMaps { get; init; }
 
     public NamedObjectSequence<ControlInstance>? Children { get; init; }
 }

--- a/src/schemas-tests/pa-yaml/v3.0/Examples/Src/Controls/control-with-namemap.pa.yaml
+++ b/src/schemas-tests/pa-yaml/v3.0/Examples/Src/Controls/control-with-namemap.pa.yaml
@@ -1,0 +1,11 @@
+Screens:
+  Screen1:
+    Children:
+      - Dropdown1:
+          Control: Classic/DropDown
+          Properties:
+            Items: |-
+              =[{Id: 1, Title: "Item 1", Desc: "desc1"}, {Id: 2, Title: "Item 2", Desc: "desc2"}, {Id: 3, Title: "Item 3", Desc: "desc3"}]
+          PropertiesNameMaps:
+            Items:
+              Value: Title


### PR DESCRIPTION
added new `PropertiesNameMaps` property on the `ControlInstance` class

```yaml
Screens:
  Screen1:
    Children:
      - Dropdown1:
          Control: Classic/DropDown
          Properties:
            Items: |-
              =[{Id: 1, Title: "Item 1", Desc: "desc1"}, {Id: 2, Title: "Item 2", Desc: "desc2"}, {Id: 3, Title: "Item 3", Desc: "desc3"}]
            X: =246
            Y: =420
          PropertiesNameMaps:
            Items:
              Value: Title
```
