### PR TITLE
Reorder component property keywords so the `PropertyKind` is first

### DIFF
--- a/src/Persistence.Tests/PaYaml/Serialization/PaYamlSerializerTests.cs
+++ b/src/Persistence.Tests/PaYaml/Serialization/PaYamlSerializerTests.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.PowerPlatform.PowerApps.Persistence;
 using Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models;
+using Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.PowerFx;
 using Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.SchemaV3;
 using Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Serialization;
 
@@ -261,4 +262,25 @@ public class PaYamlSerializerTests : VSTestBase
     }
 
     #endregion
+
+    [TestMethod]
+    public void SerializeComponentCustomPropertyUnionPropertyOrder()
+    {
+        // Since App.Properties is a NamedObjectMapping, the location info should be set on the NamedObject
+        var actualYaml = PaYamlSerializer.Serialize(new ComponentCustomPropertyUnion()
+        {
+            PropertyKind = ComponentPropertyKind.Input,
+            DisplayName = "My Property",
+            Description = "My Property Description",
+            DataType = PFxDataType.Boolean,
+            Default = new("true"),
+        });
+        actualYaml.TrimEnd().Should().Be("""
+            PropertyKind: Input
+            DisplayName: My Property
+            Description: My Property Description
+            DataType: Boolean
+            Default: =true
+            """.Replace("\r\n", "\n"));
+    }
 }

--- a/src/Persistence/PaYaml/Models/SchemaV3/ComponentDefinition.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV3/ComponentDefinition.cs
@@ -31,11 +31,13 @@ public record ComponentDefinition : IPaControlInstanceContainer
 
 public abstract record ComponentCustomPropertyBase
 {
-    [YamlMember(DefaultValuesHandling = DefaultValuesHandling.Preserve)]
+    [YamlMember(Order = -9, DefaultValuesHandling = DefaultValuesHandling.Preserve)]
     public required ComponentPropertyKind PropertyKind { get; init; }
 
+    [YamlMember(Order = -8)]
     public string? DisplayName { get; init; }
 
+    [YamlMember(Order = -7)]
     public string? Description { get; init; }
 }
 
@@ -44,13 +46,16 @@ public abstract record ComponentCustomPropertyBase
 /// </summary>
 public record ComponentCustomPropertyUnion : ComponentCustomPropertyBase
 {
-    public PFxDataType? DataType { get; init; }
-
     public bool? RaiseOnReset { get; init; }
 
-    public PFxExpressionYaml? Default { get; init; }
+    public PFxDataType? DataType { get; init; }
 
     public PFxFunctionReturnType? ReturnType { get; init; }
 
     public NamedObjectSequence<PFxFunctionParameter> Parameters { get; init; } = new();
+
+    /// <summary>
+    /// The default script for this custom input property.
+    /// </summary>
+    public PFxExpressionYaml? Default { get; init; }
 }


### PR DESCRIPTION
If this is related to an issue open in GitHub, please link it to this ticket and put the URL here.

## Problem

To normalize the output yaml for component properties, by convention, "differentiator keywords" are generally emitted first. While not a technical requirement, it allows for easier to read code and is consistent with similar patterns in the OM.

## Validation

Added unit test that verifies the order of yaml keywords.
