### PR TITLE
PaYamlV3 OM schema & PFxExpressionYamlConverter changes

### DIFF
--- a/schemas/pa-yaml/v3.0/pa.schema.yaml
+++ b/schemas/pa-yaml/v3.0/pa.schema.yaml
@@ -239,8 +239,13 @@ definitions:
     propertyNames: { $ref: "#/definitions/ComponentDefinition-name" }
     additionalProperties:
       type: object
+      required: [DefinitionType]
       additionalProperties: false
       properties:
+        DefinitionType:
+          enum:
+            - CanvasComponent
+            - CommandComponent
         Description:
           description: The description for this component definition.
           type: string
@@ -396,7 +401,6 @@ definitions:
       pattern: |-
         [.\\/:*?"<>|]
 
-
   DataSources-name-instance-map:
     type: object
     propertyNames: { $ref: "#/definitions/DataSource-name" }
@@ -478,6 +482,10 @@ definitions:
           Description: { type: string }
           IsRequired: { type: boolean }
           DataType: { $ref: "#/definitions/pfx-data-type" }
+          Default:
+            description: The default formula to use for this parameter when not explicitly specified.
+            allOf:
+              - $ref: "#/definitions/pfx-formula"
 
   pfx-function-parameter-name:
     description: The name of a Power Fx function parameter.

--- a/src/Persistence.Tests/PaYaml/Serialization/PaYamlSerializerTests.cs
+++ b/src/Persistence.Tests/PaYaml/Serialization/PaYamlSerializerTests.cs
@@ -184,6 +184,7 @@ public class PaYamlSerializerTests : VSTestBase
     [DataRow(@"_TestData/SchemaV3_0/Examples/Single-File-App.pa.yaml")]
     [DataRow(@"_TestData/SchemaV3_0/Examples/AmbiguousComponentNames.pa.yaml")]
     [DataRow(@"_TestData/SchemaV3_0/FullSchemaUses/App.pa.yaml")]
+    [DataRow(@"_TestData/SchemaV3_0/FullSchemaUses/ComponentDefinitions.pa.yaml")]
     [DataRow(@"_TestData/SchemaV3_0/FullSchemaUses/Screens-general-controls.pa.yaml")]
     [DataRow(@"_TestData/SchemaV3_0/FullSchemaUses/Screens-with-components.pa.yaml")]
     [DataRow(@"_TestData/SchemaV3_0/Examples/Src/DataSources/Dataversedatasources1.pa.yaml")]

--- a/src/Persistence/PaYaml/Models/PowerFx/PFxFunctionParameter.cs
+++ b/src/Persistence/PaYaml/Models/PowerFx/PFxFunctionParameter.cs
@@ -10,4 +10,9 @@ public record PFxFunctionParameter()
     public bool IsRequired { get; init; }
 
     public PFxDataType? DataType { get; init; }
+
+    /// <summary>
+    /// The default script for this optional parameter.
+    /// </summary>
+    public PFxExpressionYaml? Default { get; init; }
 }

--- a/src/Persistence/PaYaml/Models/SchemaV3/ComponentDefinition.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV3/ComponentDefinition.cs
@@ -6,6 +6,12 @@ using YamlDotNet.Serialization;
 
 namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.SchemaV3;
 
+public enum ComponentDefinitionType
+{
+    CanvasComponent,
+    CommandComponent,
+}
+
 public enum ComponentPropertyKind
 {
     Input,
@@ -18,6 +24,12 @@ public enum ComponentPropertyKind
 
 public record ComponentDefinition : IPaControlInstanceContainer
 {
+    // WARNING: this property is required, but yamlDotNet doesn't enforce required properties correctly.
+    // The validation here must be done by the compiler, otherwise we'll need to add a custom validator.
+    //[YamlMember(DefaultValuesHandling = DefaultValuesHandling.Preserve)]
+    //public required ComponentDefinitionType DefinitionType { get; init; }
+    public required ComponentDefinitionType? DefinitionType { get; init; }
+
     public string? Description { get; init; }
 
     public bool AccessAppScope { get; init; }

--- a/src/Persistence/PaYaml/Serialization/PFxExpressionYamlFormattingOptions.cs
+++ b/src/Persistence/PaYaml/Serialization/PFxExpressionYamlFormattingOptions.cs
@@ -1,6 +1,8 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Collections.Immutable;
+
 namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Serialization;
 
 public record PFxExpressionYamlFormattingOptions
@@ -8,5 +10,5 @@ public record PFxExpressionYamlFormattingOptions
     public const char ScalarPrefix = '=';
 
     // Note: By default, we no longer force literal block when it contains a double quote, as these are not a problem when the '=' prefix is used.
-    public IReadOnlyList<string>? ForceLiteralBlockIfContainsAny { get; init; }
+    public ImmutableArray<string> ForceLiteralBlockIfContainsAny { get; init; } = [];
 }

--- a/src/schemas-tests/pa-yaml/v3.0/Examples/AmbiguousComponentNames.pa.yaml
+++ b/src/schemas-tests/pa-yaml/v3.0/Examples/AmbiguousComponentNames.pa.yaml
@@ -10,8 +10,10 @@ App:
 
 ComponentDefinitions:
   Slider:
+    DefinitionType: CanvasComponent
     Description: A local custom Component with the same name as a 1P ControlTypeId.
   slicer:
+    DefinitionType: CanvasComponent
     Description: A local custom Component with the same name as a 1P ControlTypeId, that differs by case only
 
 Screens:

--- a/src/schemas-tests/pa-yaml/v3.0/Examples/Src/Components/MyHeaderComponent.pa.yaml
+++ b/src/schemas-tests/pa-yaml/v3.0/Examples/Src/Components/MyHeaderComponent.pa.yaml
@@ -1,5 +1,6 @@
 ComponentDefinitions:
   MyHeaderComponent:
+    DefinitionType: CanvasComponent
     Description: A header component for all screens in this app.
     AccessAppScope: true # set to true, to override the default
     CustomProperties:
@@ -75,6 +76,7 @@ ComponentDefinitions:
               IsRequired: true
           - parameter3:
               DataType: Text
+              Default: ="Hello"
           - param4:
               DataType: Number
 

--- a/src/schemas-tests/pa-yaml/v3.0/FullSchemaUses/ComponentDefinitions.pa.yaml
+++ b/src/schemas-tests/pa-yaml/v3.0/FullSchemaUses/ComponentDefinitions.pa.yaml
@@ -1,0 +1,28 @@
+ComponentDefinitions:
+  Component1:
+    DefinitionType: CanvasComponent
+    Description: Component1 description.
+    AccessAppScope: true
+    CustomProperties:
+      property1:
+        PropertyKind: Input
+        DisplayName: Property1
+        Description: Property1 description.
+        DataType: Text
+        RaiseOnReset: true
+        Default: =true // comment1
+    Properties:
+      Prop2: =screen1Prop2
+      Prop1: =screen1Prop1
+
+    Children:
+      - ctrlB:
+          Control: Label@1.2.3
+          Properties:
+            Prop2: =ctrlAProp2
+            Prop1: =ctrlAProp1
+
+  Component2:
+    DefinitionType: CommandComponent
+    Description: Component2 description.
+    AccessAppScope: true

--- a/src/schemas-tests/pa-yaml/v3.0/FullSchemaUses/Screens-with-components.pa.yaml
+++ b/src/schemas-tests/pa-yaml/v3.0/FullSchemaUses/Screens-with-components.pa.yaml
@@ -12,7 +12,7 @@ Screens:
             Prop2: =ctrlBProp2
             Prop1: =ctrlBProp1
 
-      # Purposesly set out of name sorting order to ensure ordering is maintained
+      # Purposely set out of name sorting order to ensure ordering is maintained
       - ctrlA:
           Control: Component
           ComponentName: externComponent2

--- a/src/schemas/pa-yaml/v3.0/pa.schema.yaml
+++ b/src/schemas/pa-yaml/v3.0/pa.schema.yaml
@@ -261,8 +261,13 @@ definitions:
     propertyNames: { $ref: "#/definitions/ComponentDefinition-name" }
     additionalProperties:
       type: object
+      required: [DefinitionType]
       additionalProperties: false
       properties:
+        DefinitionType:
+          enum:
+            - CanvasComponent
+            - CommandComponent
         Description:
           description: The description for this component definition.
           type: string
@@ -431,7 +436,6 @@ definitions:
       pattern: |-
         [.\\/:*?"<>|]
 
-
   DataSources-name-instance-map:
     type: object
     propertyNames: { $ref: "#/definitions/DataSource-name" }
@@ -514,6 +518,10 @@ definitions:
           Description: { type: string }
           IsRequired: { type: boolean }
           DataType: { $ref: "#/definitions/pfx-data-type" }
+          Default:
+            description: The default formula to use for this parameter when not explicitly specified.
+            allOf:
+              - $ref: "#/definitions/pfx-formula"
 
   pfx-function-parameter-name:
     description: The name of a Power Fx function parameter.


### PR DESCRIPTION
- `PFxFunctionParameter` now supports `Default` keyword being a PFx expression.
- `ComponentDefinition.DefinitionType` added with enum `ComponentDefinitionType`, to differentiate between Canvas and Command components.
- Added tests for `PFxExpressionYamlConverter` to show the handling of trailing whitespace. Turns out YamlDotNet cannot support us forcing these to use Literal block syntax.
- Adapted to add quotes around values which end with the tab character.
- Use ImmutableArray instead of IReadOnlyList for options.
- Updated `pa.schema.yaml` and added more tests.
