### PR TITLE
Fix OM to allow detection of missing keywords

### DIFF
--- a/src/Persistence/PaYaml/Models/NamedObjectCollectionExtensions.cs
+++ b/src/Persistence/PaYaml/Models/NamedObjectCollectionExtensions.cs
@@ -1,16 +1,28 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
+using System.Diagnostics.CodeAnalysis;
+using System.Runtime.CompilerServices;
+
 namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models;
 
 public static class NamedObjectCollectionExtensions
 {
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsNullOrEmpty<TValue>([NotNullWhen(false)] this IReadOnlyNamedObjectCollection<TValue>? collection)
+        where TValue : notnull
+    {
+        return collection is null || collection.Count == 0;
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static NamedObjectMapping<TValue>? EmptyToNull<TValue>(this NamedObjectMapping<TValue>? collection)
         where TValue : notnull
     {
         return collection?.Count == 0 ? null : collection;
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static NamedObjectSequence<TValue>? EmptyToNull<TValue>(this NamedObjectSequence<TValue>? collection)
         where TValue : notnull
     {

--- a/src/Persistence/PaYaml/Models/SchemaV3/ComponentDefinition.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV3/ComponentDefinition.cs
@@ -8,12 +8,22 @@ namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.SchemaV3;
 
 public enum ComponentDefinitionType
 {
+    /// <summary>
+    /// Indicates a value which has either not been set or has been determined to be invalid.
+    /// </summary>
+    Invalid = 0,
+
     CanvasComponent,
     CommandComponent,
 }
 
 public enum ComponentPropertyKind
 {
+    /// <summary>
+    /// Indicates a value which has either not been set or has been determined to be invalid.
+    /// </summary>
+    Invalid = 0,
+
     Input,
     Output,
     InputFunction,
@@ -58,7 +68,7 @@ public record ComponentDefinition : IPaControlInstanceContainer
 public abstract record ComponentCustomPropertyBase
 {
     [YamlMember(Order = -9, DefaultValuesHandling = DefaultValuesHandling.Preserve)]
-    public required ComponentPropertyKind PropertyKind { get; init; }
+    public required ComponentPropertyKind? PropertyKind { get; init; }
 
     [YamlMember(Order = -8)]
     public string? DisplayName { get; init; }
@@ -90,7 +100,7 @@ public record ComponentCustomPropertyParameter()
 {
     public string? Description { get; init; }
 
-    public bool IsOptional { get; init; }
+    public bool? IsOptional { get; init; }
 
     public PaYamlPropertyDataType? DataType { get; init; }
 

--- a/src/Persistence/PaYaml/Models/SchemaV3/ControlInstance.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV3/ControlInstance.cs
@@ -18,7 +18,7 @@ public record ControlInstance : IPaControlInstanceContainer
     }
 
     [property: YamlMember(Alias = "Control")]
-    public required string ControlType { get; init; }
+    public required string? ControlType { get; init; }
 
     public string? Variant { get; init; }
 

--- a/src/Persistence/PaYaml/Models/SchemaV3/DataSourceInstance.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV3/DataSourceInstance.cs
@@ -13,7 +13,7 @@ public enum DataSourceType
 public record DataSourceInstance
 {
     [YamlMember(DefaultValuesHandling = DefaultValuesHandling.Preserve)]
-    public required DataSourceType Type { get; init; }
+    public required DataSourceType? Type { get; init; }
     public string? ConnectorId { get; init; }
     public NamedObjectMapping<string>? Parameters { get; init; }
 }

--- a/src/Persistence/PaYaml/Models/SchemaV3/PaModule.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV3/PaModule.cs
@@ -9,7 +9,10 @@ namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.SchemaV3;
 public record PaModule
 {
     public AppInstance? App { get; init; }
-    public NamedObjectMapping<ComponentDefinition> ComponentDefinitions { get; init; } = new();
-    public NamedObjectMapping<ScreenInstance> Screens { get; init; } = new();
-    public NamedObjectMapping<DataSourceInstance> DataSources { get; init; } = new();
+
+    public NamedObjectMapping<ComponentDefinition>? ComponentDefinitions { get; init; }
+
+    public NamedObjectMapping<ScreenInstance>? Screens { get; init; }
+
+    public NamedObjectMapping<DataSourceInstance>? DataSources { get; init; }
 }

--- a/src/Persistence/PaYaml/Models/SchemaV3/PaYamlPropertyDataType.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV3/PaYamlPropertyDataType.cs
@@ -6,6 +6,11 @@ namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.SchemaV3;
 public enum PaYamlPropertyDataType
 {
     /// <summary>
+    /// Indicates an data type which has either not been explicitly set or has been determined to be invalid.
+    /// </summary>
+    Invalid = 0,
+
+    /// <summary>
     /// aka Void. Only valid for function return types which are allowed to have side effects.
     /// </summary>
     None,


### PR DESCRIPTION
In order to allow the PaYamlParser to detect when a keyword is missing, we need to ensure value types are allowed to be set to null. Also, to reduce memory footprint, collections are allowed to be null too.