### PR TITLE
Add `MetadataKey` keyword to control instances

### DIFF
--- a/schemas/pa-yaml/v3.0/pa.schema.yaml
+++ b/schemas/pa-yaml/v3.0/pa.schema.yaml
@@ -209,6 +209,9 @@ definitions:
         Variant:
           type: string
           minLength: 1
+        MetadataKey:
+          type: string
+          minLength: 1
         Layout:
           type: string
           minLength: 1

--- a/src/Persistence/PaYaml/Models/SchemaV3/ControlInstance.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV3/ControlInstance.cs
@@ -26,6 +26,8 @@ public record ControlInstance : IPaControlInstanceContainer
 
     public string? ComponentLibraryUniqueName { get; init; }
 
+    public string? MetadataKey { get; init; }
+
     public string? Layout { get; init; }
 
     public bool? IsLocked { get; init; }

--- a/src/schemas-tests/pa-yaml/v3.0/FullSchemaUses/Screens-general-controls.pa.yaml
+++ b/src/schemas-tests/pa-yaml/v3.0/FullSchemaUses/Screens-general-controls.pa.yaml
@@ -37,6 +37,7 @@ Screens:
             - ctrlC0:
                 Control: Bar
                 Variant: variantC0
+                MetadataKey: metadataKeyC0
                 Layout: layoutC0
                 Group: Group1
                 Properties:
@@ -59,4 +60,5 @@ Screens:
                   - ctrlC10:
                       Control: Dog
                       Variant: variantC10
+                      MetadataKey: metadataKeyC0
                       Layout: layoutC10

--- a/src/schemas/pa-yaml/v3.0/pa.schema.yaml
+++ b/src/schemas/pa-yaml/v3.0/pa.schema.yaml
@@ -230,6 +230,9 @@ definitions:
         Variant:
           type: string
           minLength: 1
+        MetadataKey:
+          type: string
+          minLength: 1
         Layout:
           type: string
           minLength: 1


### PR DESCRIPTION
## Problem

For dataCard and typedDataCard instances, we must enable setting a `MetadataKey` which will be mapped to a `metadataId` in the control template's variant so that changing layouts will work.

## Validation

- Added unit tests coverage.
