### PR TITLE
Add DisplayOrder Field to Screen Schema

### DIFF
--- a/schemas/pa-yaml/v3.0/pa.schema.yaml
+++ b/schemas/pa-yaml/v3.0/pa.schema.yaml
@@ -59,10 +59,10 @@ definitions:
     type: object
     additionalProperties: false
     properties:
-      Properties: { $ref: "#/definitions/Properties-formula-map" }
-      Children: { $ref: "#/definitions/Children-Control-instance-sequence" }
       DisplayOrder:
         type: integer
+      Properties: { $ref: "#/definitions/Properties-formula-map" }
+      Children: { $ref: "#/definitions/Children-Control-instance-sequence" }
 
   Children-Control-instance-sequence:
     description: >-

--- a/schemas/pa-yaml/v3.0/pa.schema.yaml
+++ b/schemas/pa-yaml/v3.0/pa.schema.yaml
@@ -61,6 +61,8 @@ definitions:
     properties:
       Properties: { $ref: "#/definitions/Properties-formula-map" }
       Children: { $ref: "#/definitions/Children-Control-instance-sequence" }
+      DisplayOrder:
+        type: integer
 
   Children-Control-instance-sequence:
     description: >-

--- a/src/Persistence/PaYaml/Models/SchemaV3/ScreenInstance.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV3/ScreenInstance.cs
@@ -7,9 +7,9 @@ namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.SchemaV3;
 
 public record ScreenInstance : IPaControlInstanceContainer
 {
+    public int? DisplayOrder { get; init; }
+
     public NamedObjectMapping<PFxExpressionYaml>? Properties { get; init; }
 
     public NamedObjectSequence<ControlInstance>? Children { get; init; }
-
-    public int? DisplayOrder { get; init; }
 }

--- a/src/Persistence/PaYaml/Models/SchemaV3/ScreenInstance.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV3/ScreenInstance.cs
@@ -10,4 +10,6 @@ public record ScreenInstance : IPaControlInstanceContainer
     public NamedObjectMapping<PFxExpressionYaml>? Properties { get; init; }
 
     public NamedObjectSequence<ControlInstance>? Children { get; init; }
+
+    public int? DisplayOrder { get; init; }
 }

--- a/src/schemas-tests/pa-yaml/v3.0/Examples/Src/Screens/Screen1.pa.yaml
+++ b/src/schemas-tests/pa-yaml/v3.0/Examples/Src/Screens/Screen1.pa.yaml
@@ -1,5 +1,6 @@
 Screens:
   Screen1:
+    DisplayOrder: 1
     Properties:
       Fill: =RGBA(200, 200, 200, 1)
       OnVisible: |-

--- a/src/schemas-tests/pa-yaml/v3.0/FullSchemaUses/Screens-general-controls.pa.yaml
+++ b/src/schemas-tests/pa-yaml/v3.0/FullSchemaUses/Screens-general-controls.pa.yaml
@@ -1,5 +1,6 @@
 Screens:
   screenName2:
+    DisplayOrder: 2
     Properties:
       Prop2: =screen1Prop2
       Prop1: =screen1Prop1
@@ -25,6 +26,7 @@ Screens:
             Prop1: =ctrlAProp1
 
   screenName1:
+    DisplayOrder: 1
     Children:
       - ctrlC:
           Control: FooWithChildren

--- a/src/schemas/pa-yaml/v3.0/pa.schema.yaml
+++ b/src/schemas/pa-yaml/v3.0/pa.schema.yaml
@@ -65,10 +65,10 @@ definitions:
     type: object
     additionalProperties: false
     properties:
-      Properties: { $ref: "#/definitions/Properties-formula-map" }
-      Children: { $ref: "#/definitions/Children-Control-instance-sequence" }
       DisplayOrder:
         type: integer
+      Properties: { $ref: "#/definitions/Properties-formula-map" }
+      Children: { $ref: "#/definitions/Children-Control-instance-sequence" }
 
   Children-Control-instance-sequence:
     description: >-

--- a/src/schemas/pa-yaml/v3.0/pa.schema.yaml
+++ b/src/schemas/pa-yaml/v3.0/pa.schema.yaml
@@ -67,6 +67,8 @@ definitions:
     properties:
       Properties: { $ref: "#/definitions/Properties-formula-map" }
       Children: { $ref: "#/definitions/Children-Control-instance-sequence" }
+      DisplayOrder:
+        type: integer
 
   Children-Control-instance-sequence:
     description: >-


### PR DESCRIPTION
This PR introduces the DisplayOrder field to the Screen schema, allowing the display order of a screen in PowerApps to be persisted. The field is defined as a nullable integer. Additionally, the PR updates the relevant schema definitions and test cases.