### PR TITLE
Revert Display Order Persistence Feature to Support New Design Implementation

### DIFF
--- a/schemas/pa-yaml/v3.0/pa.schema.yaml
+++ b/schemas/pa-yaml/v3.0/pa.schema.yaml
@@ -59,8 +59,6 @@ definitions:
     type: object
     additionalProperties: false
     properties:
-      DisplayOrder:
-        type: integer
       Properties: { $ref: "#/definitions/Properties-formula-map" }
       Children: { $ref: "#/definitions/Children-Control-instance-sequence" }
 

--- a/src/Persistence/PaYaml/Models/SchemaV3/ScreenInstance.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV3/ScreenInstance.cs
@@ -7,8 +7,6 @@ namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.SchemaV3;
 
 public record ScreenInstance : IPaControlInstanceContainer
 {
-    public int? DisplayOrder { get; init; }
-
     public NamedObjectMapping<PFxExpressionYaml>? Properties { get; init; }
 
     public NamedObjectSequence<ControlInstance>? Children { get; init; }

--- a/src/schemas-tests/pa-yaml/v3.0/Examples/Src/Screens/Screen1.pa.yaml
+++ b/src/schemas-tests/pa-yaml/v3.0/Examples/Src/Screens/Screen1.pa.yaml
@@ -1,6 +1,5 @@
 Screens:
   Screen1:
-    DisplayOrder: 1
     Properties:
       Fill: =RGBA(200, 200, 200, 1)
       OnVisible: |-

--- a/src/schemas-tests/pa-yaml/v3.0/FullSchemaUses/Screens-general-controls.pa.yaml
+++ b/src/schemas-tests/pa-yaml/v3.0/FullSchemaUses/Screens-general-controls.pa.yaml
@@ -1,6 +1,5 @@
 Screens:
   screenName2:
-    DisplayOrder: 2
     Properties:
       Prop2: =screen1Prop2
       Prop1: =screen1Prop1
@@ -26,7 +25,6 @@ Screens:
             Prop1: =ctrlAProp1
 
   screenName1:
-    DisplayOrder: 1
     Children:
       - ctrlC:
           Control: FooWithChildren

--- a/src/schemas/pa-yaml/v3.0/pa.schema.yaml
+++ b/src/schemas/pa-yaml/v3.0/pa.schema.yaml
@@ -65,8 +65,6 @@ definitions:
     type: object
     additionalProperties: false
     properties:
-      DisplayOrder:
-        type: integer
       Properties: { $ref: "#/definitions/Properties-formula-map" }
       Children: { $ref: "#/definitions/Children-Control-instance-sequence" }
 


### PR DESCRIPTION
This PR reverts the feature that persisted the display order of screens. The change is being made to align with a revised implementation design aimed at minimizing diff noise when adding a new screen.