### PR TITLE
Add EditorState to PA YAML schema to support editor UI ordering

### DIFF
--- a/schemas/pa-yaml/v3.0/pa.schema.yaml
+++ b/schemas/pa-yaml/v3.0/pa.schema.yaml
@@ -16,6 +16,8 @@ properties:
     $ref: "#/definitions/ComponentDefinitions-name-instance-map"
   DataSources:
     $ref: "#/definitions/DataSources-name-instance-map"
+  EditorState:
+    $ref: "#/definitions/EditorState-instance"
 
 defaultSnippets:
   - label: App
@@ -502,6 +504,22 @@ definitions:
       $ref: "#/definitions/entity-property-name"
     additionalProperties:
       $ref: "#/definitions/pfx-formula"
+
+  EditorState-instance:
+    description: Represents editor state information that's not part of the app logic but helps with editing experience.
+    type: object
+    additionalProperties: false
+    properties:
+      ScreensOrder:
+        description: Ordered list of screen names representing the order in the editor.
+        type: array
+        items:
+          $ref: "#/definitions/Screen-name"
+      ComponentDefinitionsOrder:
+        description: Ordered list of component definition names representing the order in the editor.
+        type: array
+        items:
+          $ref: "#/definitions/ComponentDefinition-name"
 
   entity-name:
     description: The base requirements for a named entity in an app.

--- a/schemas/pa-yaml/v3.0/pa.schema.yaml
+++ b/schemas/pa-yaml/v3.0/pa.schema.yaml
@@ -17,7 +17,7 @@ properties:
   DataSources:
     $ref: "#/definitions/DataSources-name-instance-map"
   EditorState:
-    $ref: "#/definitions/EditorState-instance"
+    $ref: "#/definitions/EditorState"
 
 defaultSnippets:
   - label: App
@@ -505,7 +505,7 @@ definitions:
     additionalProperties:
       $ref: "#/definitions/pfx-formula"
 
-  EditorState-instance:
+  EditorState:
     description: Represents editor state information that's not part of the app logic but helps with editing experience.
     type: object
     additionalProperties: false

--- a/schemas/pa-yaml/v3.0/pa.schema.yaml
+++ b/schemas/pa-yaml/v3.0/pa.schema.yaml
@@ -506,7 +506,7 @@ definitions:
       $ref: "#/definitions/pfx-formula"
 
   EditorState:
-    description: Represents editor state information that's not part of the app logic but helps with editing experience.
+    description: Represents metadata related to the editor state of the application that enhances the editing experience.
     type: object
     additionalProperties: false
     properties:

--- a/src/Persistence.Tests/PaYaml/Serialization/PaYamlSerializerTests.cs
+++ b/src/Persistence.Tests/PaYaml/Serialization/PaYamlSerializerTests.cs
@@ -191,6 +191,7 @@ public class PaYamlSerializerTests : VSTestBase
     [DataRow(@"_TestData/SchemaV3_0/FullSchemaUses/Screens-general-controls.pa.yaml")]
     [DataRow(@"_TestData/SchemaV3_0/FullSchemaUses/Screens-with-components.pa.yaml")]
     [DataRow(@"_TestData/SchemaV3_0/Examples/Src/DataSources/Dataversedatasources1.pa.yaml")]
+    [DataRow(@"_TestData/SchemaV3_0/Examples/Src/_EditorState.pa.yaml")]
     public void RoundTripFromYaml(string path)
     {
         var originalYaml = File.ReadAllText(path);

--- a/src/Persistence/PaYaml/Models/SchemaV3/EditorStateInstance.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV3/EditorStateInstance.cs
@@ -1,13 +1,13 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Collections.Generic;
+using System.Collections.Immutable;
 
 namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.SchemaV3;
 
 public record EditorStateInstance
 {
-    public IList<string>? ScreensOrder { get; init; }
+    public ImmutableArray<string>? ScreensOrder { get; init; }
 
-    public IList<string>? ComponentDefinitionsOrder { get; init; }
+    public ImmutableArray<string>? ComponentDefinitionsOrder { get; init; }
 }

--- a/src/Persistence/PaYaml/Models/SchemaV3/EditorStateInstance.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV3/EditorStateInstance.cs
@@ -1,13 +1,11 @@
 // Copyright (c) Microsoft Corporation.
 // Licensed under the MIT License.
 
-using System.Collections.Immutable;
-
 namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.SchemaV3;
 
 public record EditorStateInstance
 {
-    public ImmutableArray<string>? ScreensOrder { get; init; }
+    public string[]? ScreensOrder { get; init; }
 
-    public ImmutableArray<string>? ComponentDefinitionsOrder { get; init; }
+    public string[]? ComponentDefinitionsOrder { get; init; }
 }

--- a/src/Persistence/PaYaml/Models/SchemaV3/EditorStateInstance.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV3/EditorStateInstance.cs
@@ -1,0 +1,13 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using System.Collections.Generic;
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.SchemaV3;
+
+public record EditorStateInstance
+{
+    public IList<string>? ScreensOrder { get; init; }
+
+    public IList<string>? ComponentDefinitionsOrder { get; init; }
+}

--- a/src/Persistence/PaYaml/Models/SchemaV3/PaModule.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV3/PaModule.cs
@@ -10,11 +10,11 @@ public record PaModule
 {
     public AppInstance? App { get; init; }
 
-    public EditorStateInstance? EditorState { get; init; }
-
     public NamedObjectMapping<ComponentDefinition>? ComponentDefinitions { get; init; }
 
     public NamedObjectMapping<ScreenInstance>? Screens { get; init; }
 
     public NamedObjectMapping<DataSourceInstance>? DataSources { get; init; }
+    
+    public EditorStateInstance? EditorState { get; init; }
 }

--- a/src/Persistence/PaYaml/Models/SchemaV3/PaModule.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV3/PaModule.cs
@@ -10,6 +10,8 @@ public record PaModule
 {
     public AppInstance? App { get; init; }
 
+    public EditorStateInstance? EditorState { get; init; }
+
     public NamedObjectMapping<ComponentDefinition>? ComponentDefinitions { get; init; }
 
     public NamedObjectMapping<ScreenInstance>? Screens { get; init; }

--- a/src/Persistence/PaYaml/Models/SchemaV3/PaModule.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV3/PaModule.cs
@@ -15,6 +15,6 @@ public record PaModule
     public NamedObjectMapping<ScreenInstance>? Screens { get; init; }
 
     public NamedObjectMapping<DataSourceInstance>? DataSources { get; init; }
-    
+
     public EditorStateInstance? EditorState { get; init; }
 }

--- a/src/schemas-tests/pa-yaml/v3.0/Examples/Src/_EditorState.pa.yaml
+++ b/src/schemas-tests/pa-yaml/v3.0/Examples/Src/_EditorState.pa.yaml
@@ -1,0 +1,8 @@
+EditorState:
+  ScreensOrder:
+    - StartScreen
+    - AScreen1
+    - AnotherScreen2
+  ComponentDefinitionsOrder:
+    - MyComponent2
+    - AnotherComponent1

--- a/src/schemas-tests/pa-yaml/v3.0/Examples/Src/_EditorState.pa.yaml
+++ b/src/schemas-tests/pa-yaml/v3.0/Examples/Src/_EditorState.pa.yaml
@@ -1,8 +1,8 @@
 EditorState:
   ScreensOrder:
-    - StartScreen
-    - AScreen1
-    - AnotherScreen2
+    - FirstScreen
+    - SecondScreen
+    - ThirdScreen
   ComponentDefinitionsOrder:
-    - MyComponent2
-    - AnotherComponent1
+    - FirstComponent
+    - SecondComponent

--- a/src/schemas-tests/pa-yaml/v3.0/FullSchemaUses/EditorStateSample.pa.yaml
+++ b/src/schemas-tests/pa-yaml/v3.0/FullSchemaUses/EditorStateSample.pa.yaml
@@ -1,0 +1,74 @@
+App:
+  Properties:
+    StartScreen: =Screen1
+
+# Screens listed in arbitrary order (alphabetical)
+Screens:
+  Screen1:
+    Properties:
+      Fill: =RGBA(255, 255, 255, 1)
+    Children:
+      - Button1:
+          Control: Button
+          Properties:
+            Text: ="Navigate to Screen2"
+            OnSelect: =Navigate(Screen2)
+            X: =40
+            Y: =40
+  Screen3:
+    Properties:
+      Fill: =RGBA(240, 240, 240, 1)
+    Children:
+      - Label1:
+          Control: Label
+          Properties:
+            Text: ="This is Screen3"
+            X: =40
+            Y: =40
+  Screen2:
+    Properties:
+      Fill: =RGBA(245, 245, 245, 1)
+    Children:
+      - Button2:
+          Control: Button
+          Properties:
+            Text: ="Navigate to Screen3"
+            OnSelect: =Navigate(Screen3)
+            X: =40
+            Y: =40
+
+# Components listed in arbitrary order
+ComponentDefinitions:
+  Component2:
+    DefinitionType: CanvasComponent
+    Properties:
+      Height: =50
+      Width: =200
+    Children:
+      - Label1:
+          Control: Label
+          Properties:
+            Text: ="Component 2"
+  Component1:
+    DefinitionType: CanvasComponent
+    Properties:
+      Height: =100
+      Width: =250
+    Children:
+      - Label1:
+          Control: Label
+          Properties:
+            Text: ="Component 1"
+
+# Editor state defines the visual order in the tree view
+EditorState:
+  # Order of screens in the tree view (logical flow of the app)
+  ScreensOrder:
+    - Screen1  # First screen (start screen)
+    - Screen2  # Second screen in navigation flow
+    - Screen3  # Third screen in navigation flow
+  
+  # Order of components in the tree view
+  ComponentDefinitionsOrder:
+    - Component1  # Primary component shown first
+    - Component2  # Secondary component shown second

--- a/src/schemas-tests/pa-yaml/v3.0/FullSchemaUses/EditorStateSample.pa.yaml
+++ b/src/schemas-tests/pa-yaml/v3.0/FullSchemaUses/EditorStateSample.pa.yaml
@@ -2,7 +2,6 @@ App:
   Properties:
     StartScreen: =Screen1
 
-# Screens listed in arbitrary order (alphabetical)
 Screens:
   Screen1:
     Properties:
@@ -37,7 +36,6 @@ Screens:
             X: =40
             Y: =40
 
-# Components listed in arbitrary order
 ComponentDefinitions:
   Component2:
     DefinitionType: CanvasComponent
@@ -60,15 +58,12 @@ ComponentDefinitions:
           Properties:
             Text: ="Component 1"
 
-# Editor state defines the visual order in the tree view
 EditorState:
-  # Order of screens in the tree view (logical flow of the app)
   ScreensOrder:
-    - Screen1  # First screen (start screen)
-    - Screen2  # Second screen in navigation flow
-    - Screen3  # Third screen in navigation flow
+    - Screen1
+    - Screen2
+    - Screen3
   
-  # Order of components in the tree view
   ComponentDefinitionsOrder:
-    - Component1  # Primary component shown first
-    - Component2  # Secondary component shown second
+    - Component1
+    - Component2

--- a/src/schemas/pa-yaml/v3.0/pa.schema.yaml
+++ b/src/schemas/pa-yaml/v3.0/pa.schema.yaml
@@ -22,7 +22,7 @@ properties:
   DataSources:
     $ref: "#/definitions/DataSources-name-instance-map"
   EditorState:
-    $ref: "#/definitions/EditorState-instance"
+    $ref: "#/definitions/EditorState"
 
 defaultSnippets:
   - label: App
@@ -543,7 +543,7 @@ definitions:
     additionalProperties:
       $ref: "#/definitions/pfx-formula"
 
-  EditorState-instance:
+  EditorState:
     description: Represents editor state information that's not part of the app logic but helps with editing experience.
     type: object
     additionalProperties: false

--- a/src/schemas/pa-yaml/v3.0/pa.schema.yaml
+++ b/src/schemas/pa-yaml/v3.0/pa.schema.yaml
@@ -544,7 +544,7 @@ definitions:
       $ref: "#/definitions/pfx-formula"
 
   EditorState:
-    description: Represents editor state information that's not part of the app logic but helps with editing experience.
+    description: Represents metadata related to the editor state of the application that enhances the editing experience.
     type: object
     additionalProperties: false
     properties:

--- a/src/schemas/pa-yaml/v3.0/pa.schema.yaml
+++ b/src/schemas/pa-yaml/v3.0/pa.schema.yaml
@@ -21,6 +21,8 @@ properties:
     $ref: "#/definitions/ComponentDefinitions-name-instance-map"
   DataSources:
     $ref: "#/definitions/DataSources-name-instance-map"
+  EditorState:
+    $ref: "#/definitions/EditorState-instance"
 
 defaultSnippets:
   - label: App
@@ -540,6 +542,22 @@ definitions:
       $ref: "#/definitions/entity-property-name"
     additionalProperties:
       $ref: "#/definitions/pfx-formula"
+
+  EditorState-instance:
+    description: Represents editor state information that's not part of the app logic but helps with editing experience.
+    type: object
+    additionalProperties: false
+    properties:
+      ScreensOrder:
+        description: Ordered list of screen names representing the order in the editor.
+        type: array
+        items:
+          $ref: "#/definitions/Screen-name"
+      ComponentDefinitionsOrder:
+        description: Ordered list of component definition names representing the order in the editor.
+        type: array
+        items:
+          $ref: "#/definitions/ComponentDefinition-name"
 
   entity-name:
     # aka: DName


### PR DESCRIPTION
## Summary
This PR adds support for the `EditorState` top-level property to the PA YAML schema files. EditorState provides editor-specific metadata that doesn't affect app functionality but improves the editing experience by preserving UI element ordering.

## Details
- Added `EditorState` as a top-level property in the schema
- Created `EditorState-instance` definition with two properties:
  - `ScreensOrder`: An ordered array of screen names for editor display
  - `ComponentDefinitionsOrder`: An ordered array of component definition names for editor display
- Schema changes align with existing C# model classes (`PaModule` and `EditorStateInstance`)
- Applied changes to both schema locations:
  - `/src/schemas/pa-yaml/v3.0/pa.schema.yaml`
  - `/schemas/pa-yaml/v3.0/pa.schema.yaml`

## Benefits
- Enables proper schema validation for EditorState in .pa.yaml files
- Provides IntelliSense for EditorState properties in VS Code
- Allows preserving UI tree order across editing sessions
- Maintains a clean separation between functional app logic and editor UI preferences

## Testing
Verified schema validation with existing example files in `/src/schemas-tests/pa-yaml/v3.0/Examples/Src/_EditorState.pa.yaml`.

## Related work
This schema change supports the existing C# model implementation in:
- `src/Persistence/PaYaml/Models/SchemaV3/PaModule.cs`
- `src/Persistence/PaYaml/Models/SchemaV3/EditorStateInstance.cs`