### PR TITLE
Unit Test for UI Bug YAML De-Serialization Not Working As Expected

### DIFF
--- a/src/Persistence.Tests/PaYaml/Serialization/PFxExpressionYamlConverterTests.cs
+++ b/src/Persistence.Tests/PaYaml/Serialization/PFxExpressionYamlConverterTests.cs
@@ -163,7 +163,7 @@ public class PFxExpressionYamlConverterTests : SerializationTestBase
         Set(gblBar, 42);
         """",
         """
-        "=Set(gblFoo, true);\n// The next line is completely blank:\n  \nSet(gblBar, 42);"
+        "=Set(gblFoo, true);\r\n// The next line is completely blank:\r\n  \r\nSet(gblBar, 42);"
         """
         );
 

--- a/src/Persistence.Tests/PaYaml/Serialization/PFxExpressionYamlConverterTests.cs
+++ b/src/Persistence.Tests/PaYaml/Serialization/PFxExpressionYamlConverterTests.cs
@@ -143,17 +143,12 @@ public class PFxExpressionYamlConverterTests : SerializationTestBase
         // BUG:31691580 YamlDotNet doesn't serialize string when spaces are added in blank lines and shows escaped string in codeview
         // LoadingPage.OnVisible with spaces on blank line in the middle, serialization adds \r\n for new lines on windows-os and \n for non-windows os
 
-        VerifySerializeWithEscapedStringInCodeView("Set(gblFoo, true);\r\n// The next line has one or more spaces:\r\n    \r\nSet(gblBar, 42);",
-            """=Set(gblFoo, true);\r\n// The next line has one or more spaces:\r\n    \r\nSet(gblBar, 42);""");
-    }
 
-    private void VerifySerializeWithEscapedStringInCodeView(string? pfxScript, string expectedExpressionYaml)
-    {
-        var expression = pfxScript is null ? null : new PFxExpressionYaml(pfxScript);
-        var testObject = new NamedPFxExpressionYaml(expression);
-        var expectedYaml = expectedExpressionYaml is null ? "Expression:" : $"Expression: \"{expectedExpressionYaml}\"\n";
-        var actualYaml = SerializeViaYamlDotNet(testObject);
-        actualYaml.Should().Be(expectedYaml);
+        VerifySerialize("Set(gblFoo,\n   \n   \"Hello world!\");",
+            "\"=Set(gblFoo,\\n   \\n   \\\"Hello world!\\\");\"");
+
+        VerifySerialize("Set(gblFoo, true);\n// The next line has one or more spaces:\n    \nSet(gblBar, 42);",
+            "\"=Set(gblFoo, true);\\n// The next line has one or more spaces:\\n    \\nSet(gblBar, 42);\"");
     }
 
     private void VerifySerialize(string? pfxScript, string expectedExpressionYaml)

--- a/src/Persistence.Tests/PaYaml/Serialization/PFxExpressionYamlConverterTests.cs
+++ b/src/Persistence.Tests/PaYaml/Serialization/PFxExpressionYamlConverterTests.cs
@@ -132,6 +132,44 @@ public class PFxExpressionYamlConverterTests : SerializationTestBase
         VerifySerialize("val1 & foo  \t", "'=val1 & foo  \t'");
     }
 
+    [TestMethod]
+    public void WriteYamlWithEscapedStringInCodeView()
+    {
+        using var _ = new AssertionScope();
+
+        VerifySerialize(
+        """" 
+        Set(gblFoo, true);
+        // The next line is completely blank:
+
+        Set(gblBar, 42);
+        """",
+        """"
+        |-
+          =Set(gblFoo, true);
+          // The next line is completely blank:
+
+          Set(gblBar, 42);
+        """");
+
+        // BUG: YamlDotNet doesn't serialize string when spaces are added in blank lines and shows escaped string in codeview
+        // LoadingPage.OnVisible with spaces on blank line in the middle, serialization adds \r\n for new lines on windows-os and \n for non-windows os
+
+        VerifySerialize(
+        """"
+        Set(gblFoo, true);
+        // The next line is completely blank:
+          
+        Set(gblBar, 42);
+        """",
+        """
+        "=Set(gblFoo, true);\n// The next line is completely blank:\n  \nSet(gblBar, 42);"
+        """
+        );
+
+
+    }
+
     private void VerifySerialize(string? pfxScript, string expectedExpressionYaml)
     {
         var expression = pfxScript is null ? null : new PFxExpressionYaml(pfxScript);


### PR DESCRIPTION
If this is related to an issue open in GitHub, please link it to this ticket and put the URL here.

## Problem

Writing Unit Test for LoadingPage.OnVisible in shows as escaped string in codeview

## Solution

Added unit test method to make this issue a known bug. Verified the code is functioning as is seen in UI.

## Changes

Added a unit test method to class PFxExpressionYamlConverterTests.cs

## Validation

Unit Test Validation