### PR TITLE
Force literal block for Unicode characters to preserve them without escaping

### DIFF
--- a/src/Persistence.Tests/PaYaml/Serialization/PFxExpressionYamlConverterTests.cs
+++ b/src/Persistence.Tests/PaYaml/Serialization/PFxExpressionYamlConverterTests.cs
@@ -151,6 +151,48 @@ public class PFxExpressionYamlConverterTests : SerializationTestBase
             "\"=Set(gblFoo, true);\\n// The next line has one or more spaces:\\n    \\nSet(gblBar, 42);\"");
     }
 
+    [TestMethod]
+    public void WriteYamlWithUnicodeCharacters()
+    {
+        using var _ = new AssertionScope();
+
+        // Test Unicode characters in PowerFx expressions are preserved
+        VerifySerialize("Set(用户名, \"John\")", "|-\n  =Set(用户名, \"John\")");
+        VerifySerialize("Text(\"こんにちは世界\")", "|-\n  =Text(\"こんにちは世界\")");
+        VerifySerialize("Format(价格, \"$#,##0.00\")", "|-\n  =Format(价格, \"$#,##0.00\")");
+
+        // Test mixed Unicode and ASCII
+        VerifySerialize("Concatenate(\"Hello \", 世界, \"!\")", "|-\n  =Concatenate(\"Hello \", 世界, \"!\")");
+
+        // Test emoji and special Unicode characters
+        VerifySerialize("Set(Status, \"✅ Complete\")", "|-\n  =Set(Status, \"✅ Complete\")");
+        VerifySerialize("Text(\"温度: \" & Temp & \"℃\")", "|-\n  =Text(\"温度: \" & Temp & \"℃\")");
+
+        // Test Unicode in variable names and strings
+        VerifySerialize("Set(变量_测试, \"龭唉𫓧G㐁A𫟦D𠳐ⅷ𫇭C丂\")", "|-\n  =Set(变量_测试, \"龭唉𫓧G㐁A𫟦D𠳐ⅷ𫇭C丂\")");
+    }
+
+    [TestMethod]
+    public void ReadYamlWithUnicodeCharacters()
+    {
+        using var _ = new AssertionScope();
+
+        // Test Unicode characters can be deserialized from literal blocks
+        VerifyDeserialize("Expression: |-\n  =Set(用户名, \"John\")", "Set(用户名, \"John\")");
+        VerifyDeserialize("Expression: |-\n  =Text(\"こんにちは世界\")", "Text(\"こんにちは世界\")");
+        VerifyDeserialize("Expression: |-\n  =Format(价格, \"$#,##0.00\")", "Format(价格, \"$#,##0.00\")");
+
+        // Test mixed Unicode and ASCII
+        VerifyDeserialize("Expression: |-\n  =Concatenate(\"Hello \", 世界, \"!\")", "Concatenate(\"Hello \", 世界, \"!\")");
+
+        // Test emoji and special Unicode characters
+        VerifyDeserialize("Expression: |-\n  =Set(Status, \"✅ Complete\")", "Set(Status, \"✅ Complete\")");
+        VerifyDeserialize("Expression: |-\n  =Text(\"温度: \" & Temp & \"℃\")", "Text(\"温度: \" & Temp & \"℃\")");
+
+        // Test complex Unicode strings
+        VerifyDeserialize("Expression: |-\n  =Set(变量_测试, \"龭唉𫓧G㐁A𫟦D𠳐ⅷ𫇭C丂\")", "Set(变量_测试, \"龭唉𫓧G㐁A𫟦D𠳐ⅷ𫇭C丂\")");
+    }
+
     private void VerifySerialize(string? pfxScript, string expectedExpressionYaml)
     {
         var expression = pfxScript is null ? null : new PFxExpressionYaml(pfxScript);

--- a/src/Persistence.Tests/PaYaml/Serialization/PFxExpressionYamlConverterTests.cs
+++ b/src/Persistence.Tests/PaYaml/Serialization/PFxExpressionYamlConverterTests.cs
@@ -156,20 +156,46 @@ public class PFxExpressionYamlConverterTests : SerializationTestBase
     {
         using var _ = new AssertionScope();
 
-        // Test Unicode characters in PowerFx expressions are preserved
-        VerifySerialize("Set(用户名, \"John\")", "|-\n  =Set(用户名, \"John\")");
-        VerifySerialize("Text(\"こんにちは世界\")", "|-\n  =Text(\"こんにちは世界\")");
-        VerifySerialize("Format(价格, \"$#,##0.00\")", "|-\n  =Format(价格, \"$#,##0.00\")");
+        // Test Unicode characters in PowerFx expressions are preserved - most now use plain scalar format with high threshold
+        VerifySerialize("""Set(用户名, "John")""", """=Set(用户名, "John")""");
+        VerifySerialize("""Text("こんにちは世界")""", """=Text("こんにちは世界")""");
+        VerifySerialize("""Format(价格, "$#,##0.00")""", """=Format(价格, "$#,##0.00")""");
 
         // Test mixed Unicode and ASCII
-        VerifySerialize("Concatenate(\"Hello \", 世界, \"!\")", "|-\n  =Concatenate(\"Hello \", 世界, \"!\")");
+        VerifySerialize("""Concatenate("Hello ", 世界, "!")""", """=Concatenate("Hello ", 世界, "!")""");
 
         // Test emoji and special Unicode characters
-        VerifySerialize("Set(Status, \"✅ Complete\")", "|-\n  =Set(Status, \"✅ Complete\")");
-        VerifySerialize("Text(\"温度: \" & Temp & \"℃\")", "|-\n  =Text(\"温度: \" & Temp & \"℃\")");
+        VerifySerialize("""Set(Status, "✅ Complete")""", """=Set(Status, "✅ Complete")""");
+        VerifySerialize("""Text("温度: " & Temp & "℃")""", "|-\n  =Text(\"温度: \" & Temp & \"℃\")");
 
-        // Test Unicode in variable names and strings
-        VerifySerialize("Set(变量_测试, \"龭唉𫓧G㐁A𫟦D𠳐ⅷ𫇭C丂\")", "|-\n  =Set(变量_测试, \"龭唉𫓧G㐁A𫟦D𠳐ⅷ𫇭C丂\")");
+        // Test Unicode in variable names and strings - high Unicode characters above 0x20CD0 use literal block to preserve them
+        VerifySerialize("""Set(变量_测试, "龭唉𫓧G㐁A𫟦D𠳐ⅷ𫇭C丂")""", "|-\n  =Set(变量_测试, \"龭唉𫓧G㐁A𫟦D𠳐ⅷ𫇭C丂\")");
+    }
+
+    [TestMethod]
+    public void WriteYamlWithLatin1SupplementCharacters()
+    {
+        using var _ = new AssertionScope();
+
+        // Currency symbols that should be preserved without escaping
+        VerifySerialize("""Set(BritishPrice, "£50.00")""", """=Set(BritishPrice, "£50.00")""");
+        VerifySerialize("""Set(JapanesePrice, "¥1000")""", """=Set(JapanesePrice, "¥1000")""");
+        VerifySerialize("""Set(EuroPrice, "€75.50")""", """=Set(EuroPrice, "€75.50")""");
+
+        // Accented characters commonly found in European languages
+        VerifySerialize("""Set(Français, true)""", """=Set(Français, true)""");
+        VerifySerialize("""Set(Español, "Niño")""", """=Set(Español, "Niño")""");
+        VerifySerialize("""Set(Deutsch, "Mädchen")""", """=Set(Deutsch, "Mädchen")""");
+        VerifySerialize("""Set(Português, "São")""", """=Set(Português, "São")""");
+
+        // Mathematical and typographical symbols
+        VerifySerialize("""Set(Temperature, "±23°C")""", """=Set(Temperature, "±23°C")""");
+        VerifySerialize("""Set(Fraction, "½ cup")""", """=Set(Fraction, "½ cup")""");
+        VerifySerialize("""Set(Multiplication, "5×3")""", """=Set(Multiplication, "5×3")""");
+
+        // Legal and business symbols
+        VerifySerialize("""Set(Copyright, "© 2024")""", """=Set(Copyright, "© 2024")""");
+        VerifySerialize("""Set(Registered, "®")""", """=Set(Registered, "®")""");
     }
 
     [TestMethod]
@@ -178,19 +204,45 @@ public class PFxExpressionYamlConverterTests : SerializationTestBase
         using var _ = new AssertionScope();
 
         // Test Unicode characters can be deserialized from literal blocks
-        VerifyDeserialize("Expression: |-\n  =Set(用户名, \"John\")", "Set(用户名, \"John\")");
-        VerifyDeserialize("Expression: |-\n  =Text(\"こんにちは世界\")", "Text(\"こんにちは世界\")");
-        VerifyDeserialize("Expression: |-\n  =Format(价格, \"$#,##0.00\")", "Format(价格, \"$#,##0.00\")");
+        VerifyDeserialize("Expression: |-\n  =Set(用户名, \"John\")", """Set(用户名, "John")""");
+        VerifyDeserialize("Expression: |-\n  =Text(\"こんにちは世界\")", """Text("こんにちは世界")""");
+        VerifyDeserialize("Expression: |-\n  =Format(价格, \"$#,##0.00\")", """Format(价格, "$#,##0.00")""");
 
         // Test mixed Unicode and ASCII
-        VerifyDeserialize("Expression: |-\n  =Concatenate(\"Hello \", 世界, \"!\")", "Concatenate(\"Hello \", 世界, \"!\")");
+        VerifyDeserialize("Expression: |-\n  =Concatenate(\"Hello \", 世界, \"!\")", """Concatenate("Hello ", 世界, "!")""");
 
         // Test emoji and special Unicode characters
-        VerifyDeserialize("Expression: |-\n  =Set(Status, \"✅ Complete\")", "Set(Status, \"✅ Complete\")");
-        VerifyDeserialize("Expression: |-\n  =Text(\"温度: \" & Temp & \"℃\")", "Text(\"温度: \" & Temp & \"℃\")");
+        VerifyDeserialize("Expression: |-\n  =Set(Status, \"✅ Complete\")", """Set(Status, "✅ Complete")""");
+        VerifyDeserialize("Expression: |-\n  =Text(\"温度: \" & Temp & \"℃\")", """Text("温度: " & Temp & "℃")""");
 
         // Test complex Unicode strings
-        VerifyDeserialize("Expression: |-\n  =Set(变量_测试, \"龭唉𫓧G㐁A𫟦D𠳐ⅷ𫇭C丂\")", "Set(变量_测试, \"龭唉𫓧G㐁A𫟦D𠳐ⅷ𫇭C丂\")");
+        VerifyDeserialize("Expression: |-\n  =Set(变量_测试, \"龭唉𫓧G㐁A𫟦D𠳐ⅷ𫇭C丂\")", """Set(变量_测试, "龭唉𫓧G㐁A𫟦D𠳐ⅷ𫇭C丂")""");
+    }
+
+    [TestMethod]
+    public void ReadYamlWithLatin1SupplementCharacters()
+    {
+        using var _ = new AssertionScope();
+
+        // Currency symbols that should be preserved when reading from plain scalar format
+        VerifyDeserialize("""Expression: =Set(BritishPrice, "£50.00")""", """Set(BritishPrice, "£50.00")""");
+        VerifyDeserialize("""Expression: =Set(JapanesePrice, "¥1000")""", """Set(JapanesePrice, "¥1000")""");
+        VerifyDeserialize("""Expression: =Set(EuroPrice, "€75.50")""", """Set(EuroPrice, "€75.50")""");
+
+        // Accented characters from European languages
+        VerifyDeserialize("""Expression: =Set(Français, true)""", """Set(Français, true)""");
+        VerifyDeserialize("""Expression: =Set(Español, "Niño")""", """Set(Español, "Niño")""");
+        VerifyDeserialize("""Expression: =Set(Deutsch, "Mädchen")""", """Set(Deutsch, "Mädchen")""");
+        VerifyDeserialize("""Expression: =Set(Português, "São")""", """Set(Português, "São")""");
+
+        // Mathematical and typographical symbols
+        VerifyDeserialize("""Expression: =Set(Temperature, "±23°C")""", """Set(Temperature, "±23°C")""");
+        VerifyDeserialize("""Expression: =Set(Fraction, "½ cup")""", """Set(Fraction, "½ cup")""");
+        VerifyDeserialize("""Expression: =Set(Multiplication, "5×3")""", """Set(Multiplication, "5×3")""");
+
+        // Legal and business symbols
+        VerifyDeserialize("""Expression: =Set(Copyright, "© 2024")""", """Set(Copyright, "© 2024")""");
+        VerifyDeserialize("""Expression: =Set(Registered, "®")""", """Set(Registered, "®")""");
     }
 
     private void VerifySerialize(string? pfxScript, string expectedExpressionYaml)

--- a/src/Persistence/PaYaml/Serialization/PFxExpressionYamlConverter.cs
+++ b/src/Persistence/PaYaml/Serialization/PFxExpressionYamlConverter.cs
@@ -58,6 +58,8 @@ public class PFxExpressionYamlConverter : IYamlTypeConverter
         // Force multi-line scripts to be literal blocks
         forceLiteralBlock |= expression.InvariantScript.Contains('\n')
             || expression.InvariantScript.Contains('\r');
+        // Force literal block for Unicode characters to preserve them without escaping
+        forceLiteralBlock |= expression.InvariantScript.Any(c => c > 127 && !char.IsControl(c));
         if (!forceLiteralBlock && !_formattingOptions.ForceLiteralBlockIfContainsAny.IsDefaultOrEmpty)
         {
             // e.g. our original code was forcing literal block if the script contained any double quotes (`"`).

--- a/src/Persistence/PaYaml/Serialization/PFxExpressionYamlConverter.cs
+++ b/src/Persistence/PaYaml/Serialization/PFxExpressionYamlConverter.cs
@@ -59,7 +59,7 @@ public class PFxExpressionYamlConverter : IYamlTypeConverter
         forceLiteralBlock |= expression.InvariantScript.Contains('\n')
             || expression.InvariantScript.Contains('\r');
         // Force literal block for Unicode characters to preserve them without escaping
-        forceLiteralBlock |= expression.InvariantScript.Any(c => c > 127 && !char.IsControl(c));
+        forceLiteralBlock |= expression.InvariantScript.Any(char.IsSurrogate);
         if (!forceLiteralBlock && !_formattingOptions.ForceLiteralBlockIfContainsAny.IsDefaultOrEmpty)
         {
             // e.g. our original code was forcing literal block if the script contained any double quotes (`"`).


### PR DESCRIPTION
Force literal block for Unicode characters to preserve them without escaping
If this is related to an issue open in GitHub, please link it to this ticket and put the URL here.

## Problem

What is the issue we are attempting to solve?
The Unicode characters were being escaped.

## Solution

What are we doing to solve this issue?
Force literal block for Unicode characters to preserve them without escaping
