### PR TITLE
Fix `PaYamlSerializer.CheckIsSequence` to return false if it encounters a `YamlException`

### DIFF
--- a/src/Persistence/PaYaml/Serialization/PaYamlSerializer.cs
+++ b/src/Persistence/PaYaml/Serialization/PaYamlSerializer.cs
@@ -162,11 +162,20 @@ public static class PaYamlSerializer
 
         var parser = new Parser(reader);
 
-        // Need to consume the StreamStart and DocumentStart events to get to the root sequence
-        parser.TryConsume<StreamStart>(out _);
-        parser.TryConsume<DocumentStart>(out _);
+        try
+        {
+            // Need to consume the StreamStart and DocumentStart events to get to the root sequence
+            parser.TryConsume<StreamStart>(out _);
+            parser.TryConsume<DocumentStart>(out _);
 
-        return parser.TryConsume<SequenceStart>(out _);
+            return parser.TryConsume<SequenceStart>(out _);
+        }
+        catch (YamlException)
+        {
+            // If we hit a YamlException, the input is not well-formed YAML, which means it can't be a sequence.
+            // This also prevents the exception from propagating to the caller.
+            return false;
+        }
     }
 
     #endregion


### PR DESCRIPTION
## Problem

For certain invalid yaml strings, this function throws a 'YamlException', forcing callers to handle it.

## Solution

This change updates the function to return `false` when this exception occurs, as it means the input is definitely not a yaml sequence.

## Validation

- added test cases which throw this exception.
