### PR TITLE
`AppInstance.Start` location is now set

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -2,7 +2,8 @@
 <configuration>
   <packageSources>
     <clear />
-    <add key="nuget" value="https://api.nuget.org/v3/index.json" />
+    <add key="azure-default" value="https://packagefeedproxy.microsoft.io/nuget/v3/index.json" protocolVersion="3" />
+    <add key="nuget.org" value="https://api.nuget.org/v3/index.json" protocolVersion="3" />
   </packageSources>
   <!--
     When CentralPackageManagement is enabled, the packageSourceMapping element helps to remove NU1507 errors.
@@ -10,8 +11,11 @@
     -->
   <packageSourceMapping>
     <!-- key value for <packageSource> should match key values from <packageSources> element -->
-    <packageSource key="nuget">
+    <packageSource key="azure-default">
       <package pattern="*" />
     </packageSource>
   </packageSourceMapping>
+  <disabledPackageSources>
+    <add key="nuget.org" value="true" />
+  </disabledPackageSources>
 </configuration>

--- a/src/Persistence.Tests/PaYaml/Serialization/PaYamlSerializerTests.cs
+++ b/src/Persistence.Tests/PaYaml/Serialization/PaYamlSerializerTests.cs
@@ -13,6 +13,14 @@ namespace Persistence.Tests.PaYaml.Serialization;
 public class PaYamlSerializerTests : VSTestBase
 {
     [TestMethod]
+    public void DeserializeAppInstanceSetsLocationInfo()
+    {
+        PaYamlSerializer.Deserialize<PaModule>("App: {}")!.App!.Start.Should().Be(new(1, 6));
+        PaYamlSerializer.Deserialize<PaModule>("\nApp: {}")!.App!.Start.Should().Be(new(2, 6));
+        PaYamlSerializer.Deserialize<PaModule>("\nApp:\n Properties: {}")!.App!.Start.Should().Be(new(3, 2));
+    }
+
+    [TestMethod]
     public void DeserializeNamedObjectSetsLocationInfo()
     {
         // Since App.Properties is a NamedObjectMapping, the location info should be set on the NamedObject
@@ -27,6 +35,7 @@ public class PaYamlSerializerTests : VSTestBase
         paModule.App.Properties.ShouldNotBeNull();
         paModule.App.Properties.Should().ContainName("Foo").WhoseNamedObject.Start.Should().Be(new(3, 9));
         paModule.App.Properties.Should().ContainName("Bar").WhoseNamedObject.Start.Should().Be(new(4, 9));
+        paModule.App.Start.Should().Be(new(2, 5), "`App.Start` location info should now be set correctly");
     }
 
     [TestMethod]

--- a/src/Persistence/Extensions/JsonExtensions.cs
+++ b/src/Persistence/Extensions/JsonExtensions.cs
@@ -8,10 +8,10 @@ namespace Microsoft.PowerPlatform.PowerApps.Persistence.Extensions;
 public static class JsonExtensions
 {
     /// <summary>
-    /// A fluent way of making a <see cref="JsonSerializerOptions"/> instance immutable.
+    /// A fluent way of calling <see cref="JsonSerializerOptions.MakeReadOnly()"/> to make a <see cref="JsonSerializerOptions"/> instance immutable.
     /// Especially useful for shared static instances.
     /// </summary>
-    public static JsonSerializerOptions ToReadOnly(this JsonSerializerOptions options)
+    public static JsonSerializerOptions MakeReadOnlyFluent(this JsonSerializerOptions options)
     {
         options.MakeReadOnly(populateMissingResolver: true);
         return options;

--- a/src/Persistence/MsApp/Serialization/MsappSerialization.cs
+++ b/src/Persistence/MsApp/Serialization/MsappSerialization.cs
@@ -38,10 +38,10 @@ public static class MsappSerialization
             // But this may have impact on other code which depends on this property.
             new JsonDateTimeAssumesUtcConverter(),
         },
-    }.ToReadOnly();
+    }.MakeReadOnlyFluent();
 
     internal static readonly JsonSerializerOptions DocumentJsonSerializeOptions = new JsonSerializerOptions(DefaultSharedJsonSerializeOptions)
-        .ToReadOnly();
+        .MakeReadOnlyFluent();
 
     /// <summary>
     /// This should match the options used in DocumentServer for deserializing msapp json files.
@@ -51,7 +51,7 @@ public static class MsappSerialization
     {
         // Note: The docsvr doesn't indent the Header.json file.
         WriteIndented = false,
-    }.ToReadOnly();
+    }.MakeReadOnlyFluent();
 
     /// <summary>
     /// Serialization options used for the 'packed.json' file in the msapp archive.
@@ -76,5 +76,5 @@ public static class MsappSerialization
         // In order to ensure forward-compatible deserialization, we ignore unknown members
         // Any object model that wants to also survive round-tripping, must use JsonExtensionData to capture those unknown members.
         UnmappedMemberHandling = JsonUnmappedMemberHandling.Skip,
-    }.ToReadOnly();
+    }.MakeReadOnlyFluent();
 }

--- a/src/Persistence/MsappPacking/Serialization/MsaprSerialization.cs
+++ b/src/Persistence/MsappPacking/Serialization/MsaprSerialization.cs
@@ -39,5 +39,5 @@ public static class MsaprSerialization
         // In order to ensure forward-compatible deserialization, we ignore unknown members
         // Any object model that wants to also survive round-tripping, must use JsonExtensionData to capture those unknown members.
         UnmappedMemberHandling = JsonUnmappedMemberHandling.Skip,
-    }.ToReadOnly();
+    }.MakeReadOnlyFluent();
 }

--- a/src/Persistence/PaYaml/Models/IMayHavePaYamlLocation.cs
+++ b/src/Persistence/PaYaml/Models/IMayHavePaYamlLocation.cs
@@ -1,0 +1,16 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models;
+
+/// <summary>
+/// An interface for objects that may have a YAML location.
+/// This is used to keep a consistent API for objects that may have a location in the YAML file.
+/// </summary>
+public interface IMayHavePaYamlLocation
+{
+    /// <summary>
+    /// The location in the YAML file where this object starts.
+    /// </summary>
+    PaYamlLocation? Start { get; }
+}

--- a/src/Persistence/PaYaml/Models/ISetPaYamlNodeLocation.cs
+++ b/src/Persistence/PaYaml/Models/ISetPaYamlNodeLocation.cs
@@ -1,0 +1,12 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models;
+
+internal interface ISetPaYamlNodeLocation : IMayHavePaYamlLocation
+{
+    /// <summary>
+    /// Sets the location of the node in the YAML file.
+    /// </summary>
+    void SetNodeLocation(PaYamlLocation? start);
+}

--- a/src/Persistence/PaYaml/Models/SchemaV3/AppInstance.cs
+++ b/src/Persistence/PaYaml/Models/SchemaV3/AppInstance.cs
@@ -6,12 +6,17 @@ using YamlDotNet.Serialization;
 
 namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models.SchemaV3;
 
-public record AppInstance
+public record AppInstance : IMayHavePaYamlLocation, ISetPaYamlNodeLocation
 {
     [YamlIgnore]
-    public PaYamlLocation? Start { get; init; }
+    public PaYamlLocation? Start { get; private set; }
 
     public NamedObjectMapping<PFxExpressionYaml>? Properties { get; init; }
+
+    void ISetPaYamlNodeLocation.SetNodeLocation(PaYamlLocation? start)
+    {
+        Start = start;
+    }
 
     // WorkItem 27966436: Support saving AppHost instances to top-level property 'App'
 }

--- a/src/Persistence/PaYaml/Serialization/PaYamlSerializationContext.cs
+++ b/src/Persistence/PaYaml/Serialization/PaYamlSerializationContext.cs
@@ -3,6 +3,7 @@
 
 using YamlDotNet.Serialization;
 using YamlDotNet.Serialization.NamingConventions;
+using YamlDotNet.Serialization.NodeDeserializers;
 
 namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Serialization;
 
@@ -29,6 +30,7 @@ public class PaYamlSerializationContext : IDisposable
         builder
             .WithDuplicateKeyChecking()
             .IgnoreFields()
+            .WithSetNodeLocationNodeDeserializerWrapper<ObjectNodeDeserializer>()
             ;
 
         if (Options.MaximumRecursion.HasValue)

--- a/src/Persistence/PaYaml/Serialization/SetNodeLocationNodeDeserializerWrapper.cs
+++ b/src/Persistence/PaYaml/Serialization/SetNodeLocationNodeDeserializerWrapper.cs
@@ -1,0 +1,53 @@
+// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+
+using Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Models;
+using YamlDotNet.Core;
+using YamlDotNet.Serialization;
+
+namespace Microsoft.PowerPlatform.PowerApps.Persistence.PaYaml.Serialization;
+
+/// <summary>
+/// A node deserializer that wraps an existing <see cref="INodeDeserializer"/> which will set the location information on the value if it implements <see cref="IMayHavePaYamlLocation"/>.
+/// </summary>
+internal sealed class SetNodeLocationNodeDeserializerWrapper<TNodeDeserializerToWrap>(TNodeDeserializerToWrap wrappedNodeDeserializer) : INodeDeserializer
+    where TNodeDeserializerToWrap : INodeDeserializer
+{
+    public bool Deserialize(IParser reader, Type expectedType, Func<IParser, Type, object?> nestedObjectDeserializer, out object? value, ObjectDeserializer rootDeserializer)
+    {
+        // Capture the start location before deserializing the node
+        var start = reader.Current?.Start;
+        if (wrappedNodeDeserializer.Deserialize(reader, expectedType, nestedObjectDeserializer, out value, rootDeserializer))
+        {
+            if (start != null && value is ISetPaYamlNodeLocation setNodeLocationValue)
+            {
+                // Only set the location if it hasn't been set yet
+                if (setNodeLocationValue.Start is null)
+                {
+                    setNodeLocationValue.SetNodeLocation(PaYamlLocation.FromMark(start.Value));
+                }
+            }
+
+            return true;
+        }
+
+        return false;
+    }
+}
+
+internal static class SetNodeLocationNodeDeserializerWrapperExtensions
+{
+    /// <summary>
+    /// Wraps the specified <typeparamref name="TNodeDeserializerToWrap"/> with a <see cref="SetNodeLocationNodeDeserializerWrapper{TNodeDeserializerToWrap}"/> which will set the location information on the value if it implements <see cref="IMayHavePaYamlLocation"/>.
+    /// </summary>
+    /// <typeparam name="TNodeDeserializerToWrap">The type of the <see cref="INodeDeserializer"/> to be replaced and wrapped.</typeparam>
+    public static DeserializerBuilder WithSetNodeLocationNodeDeserializerWrapper<TNodeDeserializerToWrap>(this DeserializerBuilder builder)
+        where TNodeDeserializerToWrap : INodeDeserializer
+    {
+        _ = builder ?? throw new ArgumentNullException(nameof(builder));
+
+        return builder.WithNodeDeserializer(
+            baseDeserializer => new SetNodeLocationNodeDeserializerWrapper<TNodeDeserializerToWrap>((TNodeDeserializerToWrap)baseDeserializer),
+            s => s.InsteadOf<TNodeDeserializerToWrap>());
+    }
+}


### PR DESCRIPTION
The `AppInstance.Start` location in PaYamlV3 wasn't getting set. It's now set.

## Changes

- `AppInstance.Start` location is now set improving yaml compilation errors.
- Update nuget.config to prefer azure-default feed over public nuget.org
- Rename `ToReadOnly` to `MakeReadOnlyFluent`
- 